### PR TITLE
Updated order in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ to run the prover. Help is available with the option `--help`.
 For instance,
 
 ```
-$ zipperposition examples/pelletier_problems/pb47.p --ord rpo6 --timeout 30
+$ zipperposition examples/pelletier_problems/pb47.p --ord epo --timeout 30
 ```
 
 To build the library, documentation, and tools, type in a terminal located in

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ to run the prover. Help is available with the option `--help`.
 For instance,
 
 ```
-$ zipperposition examples/pelletier_problems/pb47.p --ord epo --timeout 30
+$ zipperposition examples/pelletier_problems/pb47.p --timeout 30
 ```
 
 To build the library, documentation, and tools, type in a terminal located in


### PR DESCRIPTION
When I tried this command from the readme:

```bash
zipperposition examples/pelletier_problems/pb47.p --ord rpo6 --timeout 30
```

I got a long error containing the suggestion:
```bash
zipperposition: wrong argument 'rpo6'; option '--ord' expects one of: lambdafree_rpo lambda_rpo lambda_kbo lambdafree_kbo_coeff subterm lambdafree_kbo epo none.
```

So I changed the `--ord` option to take `epo`, which also seems to work.