### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.11)
-(using menhir 1.0)


### PR DESCRIPTION
Type inference is required by Menhir 20211215.