### PR TITLE
Enable Menhir type inference while keeping module aliases.

### DIFF
--- a/src/parsers/Parse_dk.mly
+++ b/src/parsers/Parse_dk.mly
@@ -2,9 +2,14 @@
 /*  Copyright 2014 Ali Assaf */
 /*  Copyright 2014 Raphaël Cauderlier */
 %{
-open Logtk
-module T = Ast_dk
-module L = ParseLocation
+
+  open Logtk
+
+  open struct
+    module T = Ast_dk
+    module L = ParseLocation
+  end
+
 %}
 %token <string> ID QID NUMBER
 %token COLON DOT DOUBLE_ARROW DEF ARROW

--- a/src/parsers/Parse_tptp.mly
+++ b/src/parsers/Parse_tptp.mly
@@ -6,9 +6,11 @@
 %{
   open Logtk
 
-  module L = ParseLocation
-  module PT = STerm
-  module A = Ast_tptp
+  open struct
+    module L = ParseLocation
+    module PT = STerm
+    module A = Ast_tptp
+  end
 
   let remove_quotes s =
     assert (s.[0] = '\'' && s.[String.length s - 1] = '\'');
@@ -197,7 +199,7 @@ app_formula:
       let loc = L.mk_pos $startpos $endpos in
       PT.app ~loc f [t]
     }
-  
+
 unitary_formula:
   | f=quantified_formula { f }
   | f=unitary_atomic_formula { f }
@@ -234,12 +236,12 @@ unary_formula:
      let loc = L.mk_pos $startpos $endpos in
      o ?loc:(Some loc) f
     }
-  | EQUAL AT f1=unary_formula AT f2=unary_formula 
+  | EQUAL AT f1=unary_formula AT f2=unary_formula
     {
-      let loc = L.mk_pos $startpos $endpos in 
+      let loc = L.mk_pos $startpos $endpos in
       PT.eq ?loc:(Some loc) f1 f2
     }
-  
+
 binary_formula:
   | f=nonassoc_binary_formula { f }
   | f=assoc_binary_formula { f }
@@ -306,9 +308,9 @@ type_arg: l=assoc_binary_formula_aux(ARROW) {
   | FORALL { PT.forall }
   | EXISTS { PT.exists }
   | LAMBDA { PT.lambda }
-  | CHOICE_BINDER { fun ?loc vars body -> 
-                      PT.app_builtin ?loc Builtin.ChoiceConst 
-                        [PT.lambda ?loc vars body] 
+  | CHOICE_BINDER { fun ?loc vars body ->
+                      PT.app_builtin ?loc Builtin.ChoiceConst
+                        [PT.lambda ?loc vars body]
                   }
 %inline unary_connective:
   | NOT { PT.not_ }
@@ -373,7 +375,7 @@ defined_atom:
   | n=INTEGER { PT.int_ (Z.of_string n) }
   | n=RATIONAL { PT.rat (Q.of_string n) }
   | n=REAL { PT.real n }
-  | CHOICE_CONST 
+  | CHOICE_CONST
     {
       let loc = L.mk_pos $startpos $endpos in
       PT.app_builtin ~loc Builtin.ChoiceConst []

--- a/src/parsers/Parse_zf.mly
+++ b/src/parsers/Parse_zf.mly
@@ -6,9 +6,11 @@
 %{
   open Logtk
 
-  module L = ParseLocation
-  module A = UntypedAST
-  module T = A.T
+  open struct
+    module L = ParseLocation
+    module A = UntypedAST
+    module T = A.T
+  end
 
   let unquote s =
     assert (s <> "");
@@ -418,4 +420,3 @@ statement:
     }
 
 %%
-

--- a/src/parsers/Tip_parser.mly
+++ b/src/parsers/Tip_parser.mly
@@ -9,8 +9,11 @@
 
 %{
   open Logtk
-  module A = Tip_ast
-  module Loc = ParseLocation
+
+  open struct
+    module A = Tip_ast
+    module Loc = ParseLocation
+  end
 
 %}
 

--- a/src/parsers/dune
+++ b/src/parsers/dune
@@ -10,8 +10,6 @@
 )
 
 (menhir
-  ;(flags (--infer))
-  (infer false)
   (modules Parse_tptp Parse_zf Parse_dk Tip_parser))
 
 (ocamllex


### PR DESCRIPTION
It's me again :-)

The fix that you (@c-cube) committed does not allow your code to work with Menhir 20211215.

This proposed fix does. We turn type inference on, and we keep the module aliases by wrapping them in `open struct ... end`, a trick suggested by Frédéric Bour (which I will document in Menhir's manual).
