### PR TITLE
Don't replace unsupported quants in ho-competitive mode

### DIFF
--- a/src/prover_calculi/booleans.ml
+++ b/src/prover_calculi/booleans.ml
@@ -2208,7 +2208,7 @@ let () =
                        "lambda-free-purify-intensional";
                        "lambda-free-extensional";
                        "ho-comb-complete";
-                       "ho-competititve";
+                       "ho-competitive";
                        "lambda-free-purify-extensional";
                        "fo-complete-basic"] (fun () ->
       _replace_quants := false;


### PR DESCRIPTION
`mode_spec` ([src/prover/params.ml:61](https://github.com/sneeuwballen/zipperposition/blob/a662708ad2b7d3c5bab13569662f209137d4b384/src/prover/params.ml#L61)) had what looked like a duplicate competitive mode, but it turned out to be just a typo.