### PR TITLE
Fix mtime oseq

### DIFF
--- a/logtk.opam
+++ b/logtk.opam
@@ -14,10 +14,10 @@ depends: [
   "base-bytes"
   "base-unix"
   ("zarith" | "num")
-  "oseq" { >= "0.3" & < "0.5" }
+  "oseq" { >= "0.5" }
   "containers" { >= "3.0" & < "4.0" }
   "containers-data" { >= "3.0" & < "4.0" }
-  "mtime" { >= "1.0"  & < "2.0"}
+  "mtime" { >= "2.0"  & < "3.0"}
   "iter" { >= "1.2" }
   "menhir" {build}
   "dune" { >= "1.11" }

--- a/src/core/Compute_prec.ml
+++ b/src/core/Compute_prec.ml
@@ -83,7 +83,7 @@ let weight_fun_of_prec ?(rank=None) ~symbols ~prec_fun =
   let w_tbl =
     ID.Set.to_list symbols
     (* inverse sorting, we want the number of *larger* symbols *)
-    |> List.sort (fun f g -> Precedence.Constr.compare_by prec_fun g f)
+    |> List.sort (fun f g -> Precedence.Constr.compare_by ~constr:prec_fun g f)
     |> CCList.foldi (fun tbl idx f -> 
         ID.Map.add f (symbol_to_rank idx) tbl) 
        ID.Map.empty in

--- a/src/core/JP_unif.ml
+++ b/src/core/JP_unif.ml
@@ -197,7 +197,7 @@ let iterate ?(flex_same=false) ~scope ~counter u v l =
       )
   in
   (* The tuple `w` can be of any length. Hence we use the sequence [[alpha], [alpha, beta], [alpha, beta, gamma], ...] *)
-  let types_w_seq = OSeq.iterate [] (fun types_w -> Type.var (H.fresh_cnt ~counter ~ty:Type.tType ()) :: types_w) in
+  let types_w_seq = OSeq.iterate (fun types_w -> Type.var (H.fresh_cnt ~counter ~ty:Type.tType ()) :: types_w) [] in
   if OSeq.is_empty positions 
   then OSeq.empty
   else 

--- a/src/core/Ordering.ml
+++ b/src/core/Ordering.ml
@@ -300,7 +300,7 @@ module MakeKBO (P : PARAMETERS) : ORD = struct
 
   (** Higher-order KBO *)
   exception UnsupportedTerm
-  let rec kbo ~prec t1 t2 =
+  let kbo ~prec t1 t2 =
     let balance = mk_balance t1 t2 in
     (** Update variable balance, weight balance, and check whether the term contains the fluid term s.
         @param pos stands for positive (is t the left term?)

--- a/src/core/Statement.ml
+++ b/src/core/Statement.ml
@@ -631,7 +631,7 @@ let sine_axiom_selector
     map in
 
   let ids_to_defs_compute defs =
-    let rec aux map d = 
+    let aux map d = 
       let update_map map id stm =
         let prev = ID.Map.get_or ~default:InpStmSet.empty id map in
         ID.Map.add id (InpStmSet.add stm prev) map in
@@ -659,7 +659,7 @@ let sine_axiom_selector
 
 
   let categorize_formulas forms =
-    let rec do_categorize (defs, helpers, axioms, conjs) f =
+    let do_categorize (defs, helpers, axioms, conjs) f =
       match view f with 
       | Def _ | Rewrite _ -> (f::defs, helpers, axioms, conjs)
       | Assert _ -> (defs, helpers, f::axioms, conjs)

--- a/src/core/Util.ml
+++ b/src/core/Util.ml
@@ -12,7 +12,7 @@ let start_ = Mtime_clock.now()
 
 let get_time_mon_us () : timestamp =
   let t = Mtime_clock.now() in
-  Mtime.Span.to_us (Mtime.span start_ t)
+  (Mtime.Span.to_float_ns (Mtime.span start_ t)) *. 1e-3
 
 let total_time_s () = get_time_mon_us () *. 1e-6
 

--- a/src/prover/AC.ml
+++ b/src/prover/AC.ml
@@ -242,7 +242,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
     )
 
   let register_ac c id ty =
-    add (C.proof_parent c) id ty
+    add ~proof:(C.proof_parent c) id ty
 
   let scan_clause c =
     let exception Fail in

--- a/src/prover/clause.ml
+++ b/src/prover/clause.ml
@@ -111,7 +111,7 @@ module Make(Ctx : Ctx.S) : S with module Ctx = Ctx = struct
     (* create the structure *)
     let ord = Ctx.ord () in
     let max_lits = lazy ( BV.to_list @@ Lits.maxlits sclause.lits ~ord ) in
-    let rec c = {
+    let c = {
       sclause;
       penalty;
       selected;

--- a/src/prover/clauseQueue.ml
+++ b/src/prover/clauseQueue.ml
@@ -386,7 +386,7 @@ module Make(C : Clause_intf.S) = struct
             w_diff_l args1 args2
           | T.Fun(ty1, body1), T.Fun(ty2, body2) 
             when Type.equal ty1 ty2 && Type.equal (T.ty body1) (T.ty body2) ->
-            w_diff body1 body2
+            w_diff ~given_term:body1 ~conj_term:body2
           | _, _ -> 
             int_of_float (inst_penalty *. (w conj_term) +. gen_penalty *. (w given_term))
         and w_diff_l xs ys =

--- a/src/prover/env.ml
+++ b/src/prover/env.ml
@@ -806,7 +806,7 @@ module Make(X : sig
       match rules with
       | [] -> None
       | r :: rs ->
-        CCOpt.or_lazy ~else_:(fun () -> apply_rules rs c) (r c) in
+        CCOpt.or_lazy ~else_:(fun () -> apply_rules ~rules:rs c) (r c) in
     
     let q = Queue.create () in
     Queue.add c q;

--- a/src/prover/eprover_interface.ml
+++ b/src/prover/eprover_interface.ml
@@ -57,7 +57,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let output_empty_conj ~out =
     Format.fprintf out "thf(conj,conjecture,($false))."
 
-  let rec encode_ty_args_t ~encoded_symbols t =
+  let encode_ty_args_t ~encoded_symbols t =
     let make_new_sym mono_head =
       if not (T.is_ground mono_head) then (
          let err = 

--- a/src/prover_calculi/Higher_order.ml
+++ b/src/prover_calculi/Higher_order.ml
@@ -1719,9 +1719,9 @@ module Make(E : Env.S) : S with module Env = E = struct
               when Type.is_var (T.ty t) && not is_poly_arg_cong_res ->
               (* A polymorphic variable might be functional on the ground level *)
               let ty_args = 
-                OSeq.iterate [Type.var @@ HVar.fresh ~ty:Type.tType ()] 
-                  (fun types_w -> 
-                    Type.var (HVar.fresh ~ty:Type.tType ()) :: types_w) in
+                OSeq.iterate (fun types_w ->
+                    Type.var (HVar.fresh ~ty:Type.tType ()) :: types_w)
+                  [Type.var @@ HVar.fresh ~ty:Type.tType ()] in
               let res = 
                 ty_args
                 |> OSeq.mapi (fun arrarg_idx arrow_args ->

--- a/src/prover_calculi/app_encode.ml
+++ b/src/prover_calculi/app_encode.ml
@@ -151,7 +151,7 @@ let rec app_encode_term toplevel t  =
 (** Encode a literal *)
 let app_encode_lit lit = 
   Util.debugf ~section 2 "# Encoding Literal %a" (fun k -> k (SLiteral.pp T.pp) lit);
-  SLiteral.map (app_encode_term true) lit
+  SLiteral.map ~f:(app_encode_term true) lit
 
 (** Encode a clause *)
 let app_encode_lits lits = List.map app_encode_lit lits

--- a/src/prover_calculi/bool_encode.ml
+++ b/src/prover_calculi/bool_encode.ml
@@ -325,7 +325,7 @@ let bool_encode_lit lit =
     assert(T.equal (T.ty_exn true_term) (T.ty_exn encoded_atom));
     mk_equ_lit (bool_encode_term atom) true_term
   | Eq _ | Neq _ ->
-    SLiteral.map bool_encode_term lit
+    SLiteral.map ~f:bool_encode_term lit
 
 (** Encode a clause *)
 let bool_encode_lits lits = List.map bool_encode_lit lits

--- a/src/prover_calculi/lazy_cnf.ml
+++ b/src/prover_calculi/lazy_cnf.ml
@@ -131,7 +131,7 @@ module Make(E : Env.S) : S with module Env = E = struct
 
       let arg_combinations = CCList.cartesian_product arg_ms in
       let arg_comb_num = List.fold_left (fun acc a -> acc * (List.length a)) 1 arg_ms in
-      let fun_table = CCArray.create arg_comb_num (List.hd ret_m) in
+      let fun_table = CCArray.make arg_comb_num (List.hd ret_m) in
 
       let iter_funs () = 
         let rec aux i k =

--- a/tests/testMultiset.ml
+++ b/tests/testMultiset.ml
@@ -4,7 +4,7 @@ module Q = QCheck
 
 module M = Multiset.Make(struct
   type t = int
-  let compare i j=Pervasives.compare i j
+  let compare i j=Stdlib.compare i j
 end)
 
 (* for testing *)
@@ -146,7 +146,7 @@ let max_is_max =
   let gen = Q.(map M.of_list (list small_int)) in
   let gen = Q.set_print pp gen in
   let prop m =
-    let f x y = Comparison.of_total (Pervasives.compare x y) in
+    let f x y = Comparison.of_total (Stdlib.compare x y) in
     let l = M.max f m |> M.to_list |> List.map fst in
     List.for_all (fun x -> M.is_max f x m) l
   in

--- a/tests/testTerm.ml
+++ b/tests/testTerm.ml
@@ -110,7 +110,7 @@ let test_whnf2 = "whnf2", `Quick, fun () ->
   Alcotest.(check t_test) "whnf2" t1 t';
   ()
 
-let test_whnf2 = "patterns", `Quick, fun () ->
+let test_patterns = "patterns", `Quick, fun () ->
   let t1 = f (g a) (g b) in 
   let t2 = T.fun_ ty (f (T.bvar ~ty 0) (g (T.bvar ~ty 1))) in
   let t3 = T.fun_ ty (f (fun_var (T.bvar ~ty 0) (T.bvar ~ty 1)) (g (T.bvar ~ty 1))) in 
@@ -207,6 +207,7 @@ let suite : unit Alcotest.test_case list =
     test_app_var;
     test_whnf1;
     test_whnf2;
+    test_patterns;
     test_polymorphic_app;
     test_eta_reduce;
     test_eta_expand;


### PR DESCRIPTION
Compilation seems to break on my opam setup (switch ocaml.5.1.0) due to missing CCArray.create. I also updated opam requirements to deal with newer versions of the libraries and adapted the breaking changes. This raised the minimum requirements of mtime and oseq though - I'm not sure if you want it like this. So far I have only tested with ocaml.5.1.0.