### PR TITLE
Fix parser bug: allow TPTP keywords as symbol names in atomic_word

### DIFF
--- a/src/parsers/Parse_tptp.mly
+++ b/src/parsers/Parse_tptp.mly
@@ -491,6 +491,11 @@ variable:
 atomic_word:
   | s=SINGLE_QUOTED { remove_quotes s }
   | s=LOWER_WORD { s }
+  | FOF { "fof" }
+  | CNF { "cnf" }
+  | TFF { "tff" }
+  | THF { "thf" }
+  | INCLUDE { "include" }
 
 atomic_defined_word:
   | NOTCONST { PT.builtin Builtin.Not }


### PR DESCRIPTION
Fixes #102.

The TPTP parser rejects `fof`, `tff`, `cnf`, `thf`, and `include` as symbol names because the lexer promotes them to dedicated tokens unconditionally. The TPTP syntax has no such restriction — these are valid `atomic_word`s when they appear inside declarations.

This patch adds the five keyword tokens as alternatives in the `atomic_word` rule in `Parse_tptp.mly`.

Tested:
- Minimal reproducers with each affected keyword now parse correctly
- Normal `fof(...)` / `tff(...)` / `thf(...)` / `cnf(...)` / `include(...)` declarations still work as before
- Sledgehammer-generated `.p` files that previously triggered parse errors now solve correctly

This issue was originally identified by Alexander Steen and myself on the Isabelle mailing list.

Thanks to @nartannt for opening the issue, identifying the root cause, and suggesting the fix, which this PR implements.