### PR TITLE
Replace failwith with R_unknown fallback in role_of_string

### DIFF
--- a/src/parsers/ast_tptp.ml
+++ b/src/parsers/ast_tptp.ml
@@ -43,16 +43,21 @@ let role_of_string = function
   | "assumption" ->  R_assumption
   | "lemma" -> R_axiom (* R_lemma makes problems harder *)
   | "theorem" -> R_theorem
+  | "corollary" -> R_axiom (* TPTP standard: axiom-like, treated as lemma *)
   | "conjecture" -> R_conjecture
   | "negated_conjecture" -> R_negated_conjecture
   | "plain" -> R_plain
   | "fi_domain" -> R_finite "domain"
   | "fi_functors" -> R_finite "functors"
   | "fi_predicates" -> R_finite "predicates"
+  | "interpretation" -> R_plain (* TPTP standard: semantic specification *)
+  | "logic" -> R_plain          (* TPTP standard: logic specification *)
   | "question" -> R_question
   | "type" -> R_type
   | "unknown" -> R_unknown
-  | s -> failwith ("not a proper TPTP role: " ^ s)
+  | s ->
+    Printf.eprintf "warning: unknown TPTP role '%s', treating as unknown\n%!" s;
+    R_unknown
 
 let string_of_role = function
   | R_axiom -> "axiom"

--- a/src/parsers/ast_tptp.ml
+++ b/src/parsers/ast_tptp.ml
@@ -42,12 +42,15 @@ let role_of_string = function
   | "assumption" -> R_assumption
   | "lemma" -> R_axiom (* R_lemma makes problems harder *)
   | "theorem" -> R_theorem
+  | "corollary" -> R_axiom (* TPTP standard: axiom-like, treated as lemma *)
   | "conjecture" -> R_conjecture
   | "negated_conjecture" -> R_negated_conjecture
   | "plain" -> R_plain
   | "fi_domain" -> R_finite "domain"
   | "fi_functors" -> R_finite "functors"
   | "fi_predicates" -> R_finite "predicates"
+  | "interpretation" -> R_plain (* TPTP standard: semantic specification *)
+  | "logic" -> R_plain (* TPTP standard: logic specification *)
   | "question" -> R_question
   | "type" -> R_type
   | "unknown" -> R_unknown


### PR DESCRIPTION
Fixes #108.

## Change

Three small additions to `role_of_string` in `src/parsers/ast_tptp.ml`:

1. Add `corollary` → `R_axiom` (TPTP BNF `:==` lists `corollary` as axiom-like; handled the same way as `lemma`)
2. Add `interpretation` and `logic` → `R_plain` (TPTP-standard roles for semantic / logic specification)
3. Replace the `failwith` catch-all with a stderr warning + `R_unknown` fallback, so unrecognised roles no longer abort the prover

## Before / after

Input: `thf(test, <ROLE>, ($true)).`

| Role | Before (master) | After (this PR) |
| --- | --- | --- |
| `corollary` | `Failure("not a proper TPTP role: corollary")` (uncaught) | ✅ accepted as axiom |
| `interpretation` | `Failure(...)` (uncaught) | ✅ accepted as plain |
| `logic` | `Failure(...)` (uncaught) | ✅ accepted as plain |
| `garbage` (invalid) | `Failure(...)` (uncaught) | ✅ `R_unknown` + stderr warning |
| All previously-accepted roles | ✅ accepted | ✅ accepted (no regression) |

## Alternative

If the maintainers prefer to keep the hard failure, I'm happy to adapt the PR accordingly.