### PR TITLE
feat: add flake.nix, update to latest ocaml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,111 @@
+{
+  description = "Zipperposition - A fully automatic theorem prover for typed higher-order and beyond";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      ocamlPackages = pkgs.ocamlPackages;
+
+      propagatedBuildInputs = with ocamlPackages; [
+        zarith
+        containers
+        containers-data
+        msat
+        iter
+        mtime
+        oseq
+      ];
+
+      checkInputs = with ocamlPackages; [
+        alcotest
+        qcheck-core
+        qcheck-alcotest
+      ];
+
+      zipperposition = ocamlPackages.buildDunePackage {
+        pname = "zipperposition";
+        version = "2.1";
+        src = ./.;
+        duneVersion = "3";
+
+        nativeBuildInputs = with ocamlPackages; [
+          menhir
+        ];
+
+        inherit propagatedBuildInputs;
+
+        preBuild = ''
+          find src -name dune -exec sed -i 's/-warn-error //g; s/-a+8 //g; s/-3+8 //g; s/-32 //g' {} +
+        '';
+
+        buildPhase = ''
+          runHook preBuild
+          dune build
+          runHook postBuild
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          dune install --prefix $out --libdir $OCAMLFIND_DESTDIR logtk libzipperposition zipperposition zipperposition-tools
+          runHook postInstall
+        '';
+
+        doCheck = true;
+        inherit checkInputs;
+        checkPhase = ''
+          dune runtest
+        '';
+      };
+
+      devShell =
+        let
+          buildInputsAndPathCommon = [
+            pkgs.ocaml
+            pkgs.dune
+            ocamlPackages.ocaml-lsp
+            ocamlPackages.utop
+            ocamlPackages.cmdliner
+            ocamlPackages.re
+            ocamlPackages.stdlib-shims
+            ocamlPackages.fmt
+            ocamlPackages.astring
+            ocamlPackages.uutf
+            ocamlPackages.either
+            ocamlPackages.seq
+          ];
+        in
+        pkgs.mkShell {
+          inputsFrom = [ zipperposition ];
+          buildInputs = [
+            ocamlPackages.alcotest
+            ocamlPackages.qcheck-core
+            ocamlPackages.qcheck-alcotest
+          ]
+          ++ buildInputsAndPathCommon;
+          shellHook = ''
+            export OCAMLPATH=${
+              pkgs.lib.makeSearchPath "lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" (
+                propagatedBuildInputs ++ checkInputs ++ buildInputsAndPathCommon
+              )
+            }
+            find src -name dune -exec sed -i 's/-warn-error //g; s/-a\+8 //g; s/-3\+8 //g; s/-32 //g' {} +
+            echo "Zipperposition development environment"
+            echo "Strict warnings have been disabled in dune files."
+          '';
+        };
+
+    in
+    {
+      packages.${system}.default = zipperposition;
+      devShells.${system}.default = devShell;
+    };
+}

--- a/src/core/Builtin.mli
+++ b/src/core/Builtin.mli
@@ -108,7 +108,7 @@ val is_numeric : t -> bool
 val is_not_numeric : t -> bool
 
 val is_arith : t -> bool
-(** Any arithmetic operator, or constant *)
+(* Any arithmetic operator, or constant *)
 val is_logical_op : t -> bool
 val is_logical_binop : t -> bool
 val is_flattened_logical : t -> bool

--- a/src/core/Compute_prec.ml
+++ b/src/core/Compute_prec.ml
@@ -89,7 +89,7 @@ let weight_fun_of_prec ?(rank=None) ~symbols ~prec_fun =
        ID.Map.empty in
 
   function id ->
-    let res = CCOpt.get_or ~default:5 (ID.Map.get id w_tbl) in
+    let res = CCOption.get_or ~default:5 (ID.Map.get id w_tbl) in
     Precedence.Weight.int res
 
 let force_const_weight ~weight ~signature = function

--- a/src/core/Congruence.ml
+++ b/src/core/Congruence.ml
@@ -53,8 +53,8 @@ module Make(T : TERM) = struct
   let[@inline] set_parents_ cc t parents : t =
     { cc with parents=H.replace cc.parents t parents }
 
-  let[@inline] next_ cc t = H.get t cc.next |> CCOpt.get_or ~default:t
-  let[@inline] parents_ cc t = H.get t cc.parents |> CCOpt.get_or ~default:[]
+  let[@inline] next_ cc t = H.get t cc.next |> CCOption.get_or ~default:t
+  let[@inline] parents_ cc t = H.get t cc.parents |> CCOption.get_or ~default:[]
 
   (* find representative *)
   let rec find_ cc (t:term) : term =

--- a/src/core/DBEnv.ml
+++ b/src/core/DBEnv.ml
@@ -94,7 +94,7 @@ let of_list l =
 let to_list e = e.stack
 
 let to_list_i e =
-  List.mapi (fun i x -> CCOpt.map (CCPair.make i) x) e.stack
+  List.mapi (fun i x -> CCOption.map (CCPair.make i) x) e.stack
 
 let pp pp_x out e =
   let pp_item out = function

--- a/src/core/FV_tree.ml
+++ b/src/core/FV_tree.ml
@@ -69,7 +69,7 @@ end = struct
     | M m1, M m2 ->
       ID.Map.merge
         (fun _ o1 o2 ->
-           Some (op (CCOpt.get_or ~default o1) (CCOpt.get_or ~default o2)))
+           Some (op (CCOption.get_or ~default o1) (CCOption.get_or ~default o2)))
         m1 m2
       |> mk_m
     | L s1, L s2 -> Util.Int_set.union s1 s2 |> mk_l

--- a/src/core/FixpointUnif.ml
+++ b/src/core/FixpointUnif.ml
@@ -33,7 +33,7 @@ let path_check ~subst ~scope var t =
         if under_var || not no_prefix then None
         else raise NotUnif)
       else (
-        CCOpt.map (fun args' -> 
+        CCOption.map (fun args' -> 
             if T.same_l args args' then t else T.app hd args') 
           (aux_l ~depth ~under_var:true args))
     | T.App(hd,args) -> 
@@ -41,12 +41,12 @@ let path_check ~subst ~scope var t =
       begin match aux ~depth ~under_var hd with
         | None -> None
         | Some hd' -> 
-          CCOpt.map (fun args' -> 
+          CCOption.map (fun args' -> 
               if T.same_l args args' && T.equal hd hd' then t 
               else T.app hd' args') 
             (aux_l ~depth ~under_var args) end
     | T.AppBuiltin(b, args) -> 
-      CCOpt.map (fun args' -> 
+      CCOption.map (fun args' -> 
           if T.same_l args args' then t 
           else T.app_builtin ~ty:(T.ty t) b args') 
         (aux_l ~depth ~under_var args)
@@ -73,7 +73,7 @@ let path_check ~subst ~scope var t =
       let xs' = aux_l ~depth ~under_var xs in
       match aux ~depth ~under_var x with
       | None -> ignore(xs'); None
-      | Some t -> CCOpt.map (fun ts -> t :: ts) xs' in
+      | Some t -> CCOption.map (fun ts -> t :: ts) xs' in
 
   aux ~depth:0 ~under_var:false t
 

--- a/src/core/ID.ml
+++ b/src/core/ID.ml
@@ -123,14 +123,14 @@ exception Attr_assoc
 exception Attr_cnf_def
 
 let as_infix = payload_find ~f:(function Attr_infix s->Some s | _ -> None)
-let is_infix id = as_infix id |> CCOpt.is_some
+let is_infix id = as_infix id |> CCOption.is_some
 let as_prefix = payload_find ~f:(function Attr_prefix s->Some s | _ -> None)
-let is_prefix id = as_prefix id |> CCOpt.is_some
+let is_prefix id = as_prefix id |> CCOption.is_some
 let as_parameter id = payload_find id ~f:(function Attr_parameter i -> Some i | _ -> None)
-let is_parameter id = as_parameter id |> CCOpt.is_some
-let is_comm id = CCOpt.is_some @@ 
+let is_parameter id = as_parameter id |> CCOption.is_some
+let is_comm id = CCOption.is_some @@ 
   payload_find ~f:(function Attr_comm -> Some 1 | _ -> None) id
-let is_assoc id = CCOpt.is_some @@ 
+let is_assoc id = CCOption.is_some @@ 
   payload_find ~f:(function Attr_assoc -> Some 1 | _ -> None) id
 let is_ac id = is_comm id && is_assoc id
 

--- a/src/core/Ind_ty.ml
+++ b/src/core/Ind_ty.ml
@@ -119,7 +119,7 @@ let as_inductive_type ty = match Type.view ty with
   | Type.Fun _ | Type.Forall _ | Type.Builtin _ | Type.DB _ | Type.Var _
     -> None
 
-let as_inductive_type_exn ty = as_inductive_type ty |> CCOpt.get_exn
+let as_inductive_type_exn ty = as_inductive_type ty |> CCOption.get_exn_or "Zipper"
 
 let is_recursive (t:t) =
   let new_ = Lazy.is_val t.ty_is_rec in

--- a/src/core/JPFull.ml
+++ b/src/core/JPFull.ml
@@ -18,7 +18,7 @@ module Make (S : sig val st: Flex_state.t end) = struct
   
   let iter_rule ?(flex_same=false) ~counter ~scope t u depth  =
     JP_unif.iterate ~flex_same ~scope ~counter t u []
-    |> OSeq.map (CCOpt.map (fun s -> U.subst s, depth+1))
+    |> OSeq.map (CCOption.map (fun s -> U.subst s, depth+1))
 
   let imit_rule ~counter ~scope t u depth =
     JP_unif.imitate ~scope ~counter t u []
@@ -145,7 +145,7 @@ module Make (S : sig val st: Flex_state.t end) = struct
     (fun x y ->
        elim_vars := IntSet.empty;
        ident_vars := IntSet.empty;
-       OSeq.map (CCOpt.map Unif_subst.of_subst) (JPFull.unify_scoped x y))
+       OSeq.map (CCOption.map Unif_subst.of_subst) (JPFull.unify_scoped x y))
   
   let unify_scoped_l =  
     let counter = ref 0 in
@@ -166,5 +166,5 @@ module Make (S : sig val st: Flex_state.t end) = struct
     (fun x y ->
        elim_vars := IntSet.empty;
        ident_vars := IntSet.empty;
-       OSeq.map (CCOpt.map Unif_subst.of_subst) (JPFull.unify_scoped_l x y))
+       OSeq.map (CCOption.map Unif_subst.of_subst) (JPFull.unify_scoped_l x y))
 end

--- a/src/core/JP_unif.ml
+++ b/src/core/JP_unif.ml
@@ -349,7 +349,7 @@ let unify ~scope ~counter t0 s0 =
                  OSeq.return (unif_simple ~scope t_subst s_subst)  else
                  unify_terms t_subst s_subst ~rules:(rules @ [rulename]) in
              unifiers 
-             |> OSeq.map (CCOpt.map (fun unifier -> US.merge subst unifier))
+             |> OSeq.map (CCOption.map (fun unifier -> US.merge subst unifier))
            (* We actually want to compose the substitutions here, but merge will have the same effect. *)
            | None -> OSeq.empty
         )
@@ -372,7 +372,7 @@ let unify ~scope ~counter t0 s0 =
       else  (Util.debugf 1 "Doing JP unif %a = %a" (fun k -> k T.pp t0 T.pp s0); 
              unify_terms t' s' ~rules:[]) in
     (* let term_unifiers = unify_terms t' s' ~rules:[] in *)
-    OSeq.map (CCOpt.map (US.merge type_unifier)) term_unifiers 
+    OSeq.map (CCOption.map (US.merge type_unifier)) term_unifiers 
   | None -> OSeq.empty
 
 (* TODO: Remove tracking of rules for efficiency? *)
@@ -398,7 +398,7 @@ let unify_scoped (t0, scope0) (t1, scope1) =
        (* Util.debugf 1 "UNIFY_START %a =?= %a" (fun k -> k T.pp t0 T.pp t1); *)
        unify ~scope:unifscope ~counter (S.apply subst (t0, scope0)) (S.apply subst (t1, scope1))
        (* merge with var renaming *)
-       |> OSeq.map (CCOpt.map (US.merge subst))
+       |> OSeq.map (CCOption.map (US.merge subst))
     ) ()
 
 let unify_scoped_nonterminating t s = OSeq.filter_map (fun x -> x) (unify_scoped t s)

--- a/src/core/Literal.ml
+++ b/src/core/Literal.ml
@@ -445,14 +445,14 @@ let is_absurd lit =
   assert(no_prop_invariant lit);
   match lit with
   | Equation (l, r, false) when T.equal l r -> true
-  | Equation (l, r, true) -> CCOpt.is_some (cannot_be_eq l r)
+  | Equation (l, r, true) -> CCOption.is_some (cannot_be_eq l r)
   | False -> true
   | Equation _ | True -> false
 
 let is_absurd_tags lit = 
   assert(no_prop_invariant lit);
   match lit with
-  | Equation (l,r,true) -> cannot_be_eq l r |> CCOpt.get_or ~default:[]
+  | Equation (l,r,true) -> cannot_be_eq l r |> CCOption.get_or ~default:[]
   | Equation _  | False -> []
   | True -> assert false
 
@@ -525,7 +525,7 @@ let as_ho_predicate (lit:t) : _ option =
     end
   | _ -> None
 
-let is_ho_predicate lit = CCOpt.is_some (as_ho_predicate lit)
+let is_ho_predicate lit = CCOption.is_some (as_ho_predicate lit)
 
 let is_ho_unif lit = match lit with
   | Equation (t, u, _) when is_negativoid lit -> Term.is_ho_app t || Term.is_ho_app u
@@ -547,7 +547,7 @@ let normalize_eq lit =
     | _ -> None 
   in
 
-  let is_negativoid t = CCOpt.is_some @@ as_neg t in
+  let is_negativoid t = CCOption.is_some @@ as_neg t in
 
   let eq_builder ~pos ~neg l r =
     match as_neg l, as_neg r with
@@ -575,7 +575,7 @@ let normalize_eq lit =
           Some (eq_cons l r)
         | T.AppBuiltin (Builtin.Not, [f]) -> 
           let elim_not = mk_lit f T.true_ (not sign) in
-          Some (CCOpt.get_or ~default:elim_not (aux elim_not))
+          Some (CCOption.get_or ~default:elim_not (aux elim_not))
         | _ -> None
       end
     | Equation(lhs,rhs,sign) when is_negativoid lhs || is_negativoid rhs ->

--- a/src/core/Literals.ml
+++ b/src/core/Literals.ml
@@ -288,7 +288,7 @@ module Conv = struct
 
   let to_s_form ?allow_free_db ?(ctx) ?hooks lits =
     let ctx =
-      if CCOpt.is_some ctx then CCOpt.get_exn ctx
+      if CCOption.is_some ctx then CCOption.get_exn_or "Zipper" ctx
       else (
         let res = Type.Conv.create () in
         Type.Conv.set_maxvar res (Seq.vars lits |> T.Seq.max_var);

--- a/src/core/Ordering.ml
+++ b/src/core/Ordering.ml
@@ -330,10 +330,10 @@ module MakeKBO (P : PARAMETERS) : ORD = struct
     (* TODO: count below and above lam separately *)
       if pos then (
         add_pos_var balance t ~below_lam;
-        W.(wb + weight_var_headed), CCOpt.is_some s && (Term.equal (CCOpt.get_exn s) t)
+        W.(wb + weight_var_headed), CCOption.is_some s && (Term.equal (CCOption.get_exn_or "Zipper" s) t)
       ) else (
         add_neg_var balance t ~below_lam;
-        W.(wb - weight_var_headed), CCOpt.is_some s && (Term.equal (CCOpt.get_exn s) t)
+        W.(wb - weight_var_headed), CCOption.is_some s && (Term.equal (CCOption.get_exn_or "Zipper" s) t)
       )
     (** list version of the previous one, threaded with the check result *)
     and balance_weight_rec wb terms s ~pos ~below_lam res = match terms with

--- a/src/core/PUnif.ml
+++ b/src/core/PUnif.ml
@@ -160,7 +160,7 @@ let elim_subsets_rule  ?(max_elims=None) ~elim_vars ~counter ~scope t u depth =
            T.equal args_t.(i) args_u.(i) 
         then `Left (T.bvar ~ty (pref_len-i-1))
         else `Right (T.bvar ~ty (pref_len-i-1))) pref_tys
-    |> CCList.partition_map CCFun.id in
+    |> CCList.partition_filter_map CCFun.id in
 
   let diff_args_num = List.length diff_args in
   let end_ = match max_elims with 
@@ -206,7 +206,7 @@ module Make (St : sig val st : Flex_state.t end) = struct
         if is_ident_last then [],[]
         else (
           proj_lr ~counter ~scope ~subst s t flag (get_option PUP.k_max_app_projections)
-          |> CCList.partition_map (fun ((sub,_) as r) -> 
+          |> CCList.partition_filter_map (fun ((sub,_) as r) -> 
               let binding,_ = Subst.FO.deref sub (T.head_term s,scope) in
               let _,body = T.open_fun binding in
               if T.is_bvar body then `Left (Some r) else `Right (Some r))) in
@@ -375,7 +375,7 @@ module Make (St : sig val st : Flex_state.t end) = struct
        elim_vars := IntSet.empty;
        ident_vars := IntSet.empty;
        let res = PragUnif.unify_scoped x y in
-       OSeq.map (CCOpt.map Unif_subst.of_subst) (res))
+       OSeq.map (CCOption.map Unif_subst.of_subst) (res))
 
   let unify_scoped_l =  
     let counter = ref 0 in
@@ -398,5 +398,5 @@ module Make (St : sig val st : Flex_state.t end) = struct
        elim_vars := IntSet.empty;
        ident_vars := IntSet.empty;
        let res = PragUnif.unify_scoped_l x y in
-       OSeq.map (CCOpt.map Unif_subst.of_subst) (res))
+       OSeq.map (CCOption.map Unif_subst.of_subst) (res))
 end

--- a/src/core/ParseLocation.ml
+++ b/src/core/ParseLocation.ml
@@ -64,7 +64,7 @@ let smaller p1 p2 =
    ||  (p1.stop_line = p2.stop_line && p1.stop_column <= p2.stop_column))
 
 module Infix = struct
-  let (<+>) = CCOpt.(<+>)
+  let (<+>) = CCOption.(<+>)
 end
 include Infix
 

--- a/src/core/PatternUnif.ml
+++ b/src/core/PatternUnif.ml
@@ -176,7 +176,7 @@ let rec build_term ?(depth=0) ~subst ~scope ~counter var bvar_map t =
          proper elimination of the arguments not present in all_args
          If it is bound then dereference and try again. *)
       if not (US.FO.mem subst (Term.as_var_exn hd, scope)) then (
-        if CCOpt.is_none (get_bvars args) then raise NotInFragment;
+        if CCOption.is_none (get_bvars args) then raise NotInFragment;
 
         let new_args, subst =
           List.fold_right (fun arg (l, subst) -> (
@@ -269,7 +269,7 @@ let rec unify ~scope ~counter ~subst = function
       if not (Type.equal (T.ty s) (T.ty t)) then (
         raise NotUnifiable
       );
-      (* let ty_unif = CCOpt.get_exn ty_unif in *)
+      (* let ty_unif = CCOption.get_exn_or "Zipper" ty_unif in *)
       (* let subst = US.merge subst ty_unif in *)
       let s', t' = norm_deref subst (s,scope), norm_deref subst (t,scope) in
       (* rotating to get naked variables on the lhs *)
@@ -325,11 +325,11 @@ let rec unify ~scope ~counter ~subst = function
    For example, X 0 3 1 =?= X 1 3 2 is solved by {X -> λλλ. Y 1} *) 
 and flex_same ~counter ~scope ~subst var args_s args_t =
   let bvar_s, bvar_t = get_bvars args_s, get_bvars args_t in
-  if CCOpt.is_none bvar_s || CCOpt.is_none bvar_t then
+  if CCOption.is_none bvar_s || CCOption.is_none bvar_t then
     raise NotInFragment;
 
 
-  let bvar_s, bvar_t = CCOpt.get_exn bvar_s, CCOpt.get_exn bvar_t in
+  let bvar_s, bvar_t = CCOption.get_exn_or "Zipper" bvar_s, CCOption.get_exn_or "Zipper" bvar_t in
   assert(CCArray.length bvar_s = CCArray.length bvar_t);
   let v = Term.as_var_exn var in
   let ret_ty = Type.apply_unsafe (Term.ty var) 
@@ -363,10 +363,10 @@ and flex_diff  ~counter ~scope ~subst var_s var_t args_s args_t =
     US.FO.bind subst (Term.as_var_exn var_s,scope) (var_t,scope)
   ) else (
     let bvar_s, bvar_t = get_bvars args_s, get_bvars args_t in
-    if CCOpt.is_none bvar_s || CCOpt.is_none bvar_t then (
+    if CCOption.is_none bvar_s || CCOption.is_none bvar_t then (
       raise NotInFragment
     ) else (
-      let bvar_s, bvar_t = CCOpt.get_exn bvar_s, CCOpt.get_exn bvar_t in
+      let bvar_s, bvar_t = CCOption.get_exn_or "Zipper" bvar_s, CCOption.get_exn_or "Zipper" bvar_t in
       let new_bvars = 
         CCArray.map (fun si -> 
             match CCArray.bsearch ~cmp (fst si, Term.true_) bvar_t  with
@@ -401,10 +401,10 @@ and flex_rigid ~pref_l ~subst ~counter ~scope flex rigid =
   assert(Term.is_var hd);
 
   let bvars = get_bvars args in
-  if CCOpt.is_none bvars then
+  if CCOption.is_none bvars then
     raise NotInFragment;
 
-  let bvars = CCOpt.get_exn bvars in
+  let bvars = CCOption.get_exn_or "Zipper" bvars in
   (* let all_args = List.length pref_l = Array.length bvars in *)
   try
     let matrix, subst = 

--- a/src/core/Precedence.ml
+++ b/src/core/Precedence.ml
@@ -133,7 +133,7 @@ module Constr = struct
         else None 
       )
       |> Iter.max
-      |> CCOpt.get_or ~default:max_int in
+      |> CCOption.get_or ~default:max_int in
     (* compare by inverse frequency (higher frequency => smaller) *)
     let is_unary_max_freq _sig s1 =
       Signature.mem !_sig s1
@@ -479,7 +479,7 @@ let depth_occurrence = depth_occ_driver ~flip:true
 let max_arity signature = 
   Signature.Seq.symbols signature
   |> Iter.map (fun sym -> snd @@ Signature.arity signature sym)
-  |> Iter.max |> CCOpt.get_or ~default:max_int
+  |> Iter.max |> CCOption.get_or ~default:max_int
 
 (* weight of f = arity of f + 4 *)
 let weight_modarity ~signature =
@@ -506,7 +506,7 @@ let weight_arity0 ~signature =
     |> Iter.fold (fun acc sym -> 
         max_arity acc (sym,ID.id sym)
       ) None
-    |> CCOpt.map fst in
+    |> CCOption.map fst in
   
   function a ->
     let res = 
@@ -594,7 +594,7 @@ let lambda_def_weight lm_w db_w base_weight clauses =
     let try_extracting lhs rhs =
       match T.view lhs with
       | T.Const id ->
-        CCOpt.return_if (T.is_ground rhs) (id, rhs)
+        CCOption.return_if (T.is_ground rhs) (id, rhs)
       | T.App(hd, args) when T.is_const hd ->
         if List.for_all T.is_var args then (
           let var_set = VS.of_list (List.map T.as_var_exn args) in
@@ -608,7 +608,7 @@ let lambda_def_weight lm_w db_w base_weight clauses =
         ) else None
       | _ -> None
     in
-    let (<+>) = CCOpt.(<+>) in
+    let (<+>) = CCOption.(<+>) in
     try_extracting lhs rhs <+> try_extracting rhs lhs
   in
 

--- a/src/core/PrefWeight.ml
+++ b/src/core/PrefWeight.ml
@@ -78,7 +78,7 @@ end) = struct
           let subtree = aux Empty rest in
           Node (NodeTagMap.singleton tag subtree)
         | Node branches -> 
-          let branch = CCOpt.get_or ~default:Empty 
+          let branch = CCOption.get_or ~default:Empty 
                         (NodeTagMap.find_opt tag branches) in
           let subtree = aux branch rest in
           Node (NodeTagMap.add tag subtree branches) end

--- a/src/core/Proof.ml
+++ b/src/core/Proof.ml
@@ -416,7 +416,7 @@ module Step = struct
   let count_rules ~name p =
     let rec aux p =
       let init = 
-        CCOpt.get_or ~default: 0 (CCOpt.map (fun r -> 
+        CCOption.get_or ~default: 0 (CCOption.map (fun r -> 
           if CCString.equal (Rule.name r) name then 1 else 0)
         (rule p)) in
       List.fold_left (fun acc par -> 
@@ -469,7 +469,7 @@ module Step = struct
           | p::l -> List.fold_left combine_dist (Parent.proof p).step.dist_to_goal l
         in
         match kind with
-        | Inference _ -> CCOpt.map succ d
+        | Inference _ -> CCOption.map succ d
         | _ -> d
     in
     let inc = 

--- a/src/core/Rewrite.ml
+++ b/src/core/Rewrite.ml
@@ -107,7 +107,7 @@ let as_defined_cst id =
         | Payload_defined_cst c -> Some c
         | _ -> None)
 
-let is_defined_cst id = CCOpt.is_some (as_defined_cst id)
+let is_defined_cst id = CCOption.is_some (as_defined_cst id)
 
 module Cst_ = struct
   type t = defined_cst
@@ -130,7 +130,7 @@ module Cst_ = struct
 
   let defined_positions t = Lazy.force t.defined_positions
   let ty t = t.defined_ty
-  let level t = CCOpt.get_or ~default:0 t.defined_level
+  let level t = CCOption.get_or ~default:0 t.defined_level
 
   let pp out (t:t): unit =
     Fmt.fprintf out "(@[defined_id@ :ty %a @ :rules %a@ :positions %a@])"

--- a/src/core/Skolem.ml
+++ b/src/core/Skolem.ml
@@ -200,7 +200,7 @@ let find_def_in_ctx ~ctx form =
         let df_vars, f_vars = 
           CCPair.map_same (fun x -> Var.Set.of_iter (T.Seq.vars x)) (def_form,form) in
         if not (Var.Set.intersection_empty df_vars f_vars) then None 
-        else CCOpt.map (fun subst -> def,subst) (TypedSTerm.try_alpha_renaming def_form form)
+        else CCOption.map (fun subst -> def,subst) (TypedSTerm.try_alpha_renaming def_form form)
       | _ -> None) 
     ctx.sc_new_defs
 
@@ -280,7 +280,7 @@ let define_term ?(pattern="fun_") ~ctx ~parents rules : term_definition =
   in
   (* separate type variables and type of arguments *)
   let ty_vars, ty_args =
-    CCList.partition_map
+    CCList.partition_filter_map
       (fun t -> match T.view t with
          | T.Var v when T.Ty.is_tType (Var.ty v) -> `Left v
          | _ -> `Right (T.ty_exn t))

--- a/src/core/SolidSubsumption.ml
+++ b/src/core/SolidSubsumption.ml
@@ -180,7 +180,7 @@ module Make (S : sig val st : Flex_state.t end) = struct
     if not @@ MS.mem var subst then (
       MS.add var t subst
     ) else (
-      let old = CCOpt.get_exn @@ MS.get var subst in
+      let old = CCOption.get_exn_or "Zipper" @@ MS.get var subst in
       MS.add var (term_intersection old t) subst 
     )
 

--- a/src/core/Statement.ml
+++ b/src/core/Statement.ml
@@ -182,7 +182,7 @@ let as_defined_cst id =
           Some (Rewrite.Defined_cst.level c, Rewrite.Defined_cst.rules c)
         | _ -> None)
 
-let as_defined_cst_level id = CCOpt.map fst @@ as_defined_cst id
+let as_defined_cst_level id = CCOption.map fst @@ as_defined_cst id
 
 let is_defined_cst id = as_defined_cst id <> None
 
@@ -246,7 +246,7 @@ let level_of_rule (d:_ def_rule): int =
   |> Iter.flat_map Term.Seq.symbols
   |> Iter.filter_map as_defined_cst_level
   |> Iter.max
-  |> CCOpt.get_or ~default:0
+  |> CCOption.get_or ~default:0
 
 (** {2 Inductive Types} *)
 
@@ -982,7 +982,7 @@ let scan_stmt_for_defined_cst (st:(clause,Term.t,Type.t) t): unit = match view s
              Iter.of_list def_rules
              |> Iter.map level_of_rule
              |> Iter.max
-             |> CCOpt.get_or ~default:0
+             |> CCOption.get_or ~default:0
            and def =
              conv_rules def_rules proof
            in
@@ -991,7 +991,7 @@ let scan_stmt_for_defined_cst (st:(clause,Term.t,Type.t) t): unit = match view s
     let level =
       Iter.of_list ids_and_levels
       |> Iter.map (fun (_,l,_) -> l)
-      |> Iter.max |> CCOpt.map_or ~default:0 succ
+      |> Iter.max |> CCOption.map_or ~default:0 succ
     in
     List.iter
       (fun (id,_,def) ->

--- a/src/core/Subst.ml
+++ b/src/core/Subst.ml
@@ -338,7 +338,7 @@ module Ty : SPECIALIZED with type term = Type.t = struct
 
   let get_var subst v =
     let o = get_var subst v in
-    CCOpt.map (Scoped.map Type.of_term_unsafe) o
+    CCOption.map (Scoped.map Type.of_term_unsafe) o
 
   let find_exn subst v =
     let t = find_exn subst v in
@@ -363,7 +363,7 @@ module FO = struct
 
   let get_var subst v =
     let o = get_var subst v in
-    CCOpt.map (Scoped.map Term.of_term_unsafe) o
+    CCOption.map (Scoped.map Term.of_term_unsafe) o
 
   let find_exn subst v =
     let t = find_exn subst v in

--- a/src/core/Term.ml
+++ b/src/core/Term.ml
@@ -287,7 +287,7 @@ let as_ho_app t =
     | _ -> None
   end
 
-let is_ho_app t = CCOpt.is_some (as_ho_app t)
+let is_ho_app t = CCOption.is_some (as_ho_app t)
 
 let is_ho_pred t = is_ho_app t && Type.is_prop (ty t)
 
@@ -305,7 +305,7 @@ let rec all_combs = function
 let rec cover_with_terms ?(depth=0) ?(recurse=true) t ts =
   let n = List.length ts in
   let db = CCList.mapi (fun i x -> 
-      if CCOpt.is_some x then (i, CCOpt.get_exn x) else (-1, false_)) 
+      if CCOption.is_some x then (i, CCOption.get_exn_or "Zipper" x) else (-1, false_)) 
       ts
            |> CCList.filter_map (fun (i,x) ->
                if i!=(-1) && equal x t then 
@@ -450,7 +450,7 @@ module Seq = struct
         | x :: xs' ->
           begin match ys with
           | y :: ys' ->
-            if (not (equal x y)) && CCOpt.is_none acc then (
+            if (not (equal x y)) && CCOption.is_none acc then (
               aux (Some (x,y)) xs' ys'
             ) else if equal x y then aux acc xs' ys'
             else None
@@ -659,7 +659,7 @@ let lambda_depth t =
     | Fun (_,u) -> aux (inc_depth acc) u 
     | Var _ | DB _ | Const _ -> acc in
   let res = aux None t in
-  (* CCFormat.printf "l_depth(@[%a@])=@[%a@]@." T.pp t (CCOpt.pp CCInt.pp) res; *)
+  (* CCFormat.printf "l_depth(@[%a@])=@[%a@]@." T.pp t (CCOption.pp CCInt.pp) res; *)
   res
 
 let comb_depth t =
@@ -685,7 +685,7 @@ let comb_depth t =
     | Var _ | DB _ | Const _ -> acc in
 
   let res = aux ~comb_streak:false None t in
-  (* CCFormat.printf "c_depth(@[%a@])=@[%a@]@." T.pp t (CCOpt.pp CCInt.pp) res; *)
+  (* CCFormat.printf "c_depth(@[%a@])=@[%a@]@." T.pp t (CCOption.pp CCInt.pp) res; *)
   res
 
 let monomorphic t = Iter.is_empty (Seq.ty_vars t)
@@ -778,9 +778,9 @@ let all_positions ?(filter_formula_subterms=(fun _ _ -> None))
     | App (head, _) when not var_args && T.is_var head ->
       f (PW.make t (PB.to_pos pb))
     | AppBuiltin (hd, args) 
-      when CCOpt.is_some (filter_formula_subterms hd args) ->
+      when CCOption.is_some (filter_formula_subterms hd args) ->
       f (PW.make t (PB.to_pos pb));
-      let taken_args = CCOpt.get_exn (filter_formula_subterms hd args) in
+      let taken_args = CCOption.get_exn_or "Zipper" (filter_formula_subterms hd args) in
       let len = List.length args in
       let invi i = len - 1 - i in
       List.iter
@@ -1278,7 +1278,7 @@ module Conv = struct
           assert(Type.is_prop ty_b);
           let body = fun_ ty_arg (aux body) in
           decr depth;
-          if CCOpt.is_some previous then PT.Var_tbl.replace tbl v (CCOpt.get_exn previous)
+          if CCOption.is_some previous then PT.Var_tbl.replace tbl v (CCOption.get_exn_or "Zipper" previous)
           else PT.Var_tbl.remove tbl v;
           app_builtin ~ty:ty_b b [of_ty ty_arg; body])
       | PT.Meta _

--- a/src/core/Term.mli
+++ b/src/core/Term.mli
@@ -223,8 +223,8 @@ end
 
 val var_occurs : var:var -> t -> bool (** [var_occurs ~var t] true iff [var] in t *)
 
-val is_ground : t -> bool (** is the term ground? (no free vars) *)
-val is_linear : t -> bool (** is the term linear? (no vars occurring multiple times) *)
+val is_ground : t -> bool (* is the term ground? (no free vars) *)
+val is_linear : t -> bool (* is the term linear? (no vars occurring multiple times) *)
 val monomorphic : t -> bool (** true if the term contains no type var *)
 
 val is_beta_reducible : t -> bool
@@ -319,7 +319,7 @@ val contains_symbol : ID.t -> t -> bool
 (** High level fold-like combinators *)
 
 val all_positions :
-  ?filter_formula_subterms:(Builtin.t -> t list -> int list CCOpt.t) ->
+  ?filter_formula_subterms:(Builtin.t -> t list -> int list CCOption.t) ->
   ?vars:bool -> ?ty_args:bool -> ?var_args:bool -> ?fun_bodies:bool -> ?pos:Position.t ->
   t -> t Position.With.t Iter.t
 (** Iterate on all sub-terms with their position.

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -490,8 +490,8 @@ module Conv = struct
 
   let exit_bvar ~handle ctx v =
     let new_map = VarMap.map (fun x-> x-1) ctx.bvars_to_db in
-    if CCOpt.is_some handle then (
-      ctx.bvars_to_db <- VarMap.add v (CCOpt.get_exn handle) new_map
+    if CCOption.is_some handle then (
+      ctx.bvars_to_db <- VarMap.add v (CCOption.get_exn_or "Zipper" handle) new_map
     )
     else ctx.bvars_to_db <- new_map
 
@@ -516,7 +516,7 @@ module Conv = struct
     ctx.n <- i+1
 
   let get_maxvar ctx =
-    CCOpt.get_or ~default:0 (!(ctx.max_vars))
+    CCOption.get_or ~default:0 (!(ctx.max_vars))
   
   let incr_maxvar ctx =
     set_maxvar ctx (get_maxvar ctx + 1)

--- a/src/core/Type.mli
+++ b/src/core/Type.mli
@@ -283,7 +283,7 @@ module Conv : sig
   val clear : ctx -> unit
 
   val enter_bvar : ctx -> VarMap.key -> int option
-  val exit_bvar  : handle:int CCOpt.t -> ctx -> VarMap.key -> unit
+  val exit_bvar  : handle:int CCOption.t -> ctx -> VarMap.key -> unit
   val find_bvar  : ctx -> VarMap.key -> int option
   val get_maxvar : ctx -> int
   val incr_maxvar : ctx -> unit

--- a/src/core/TypeInference.ml
+++ b/src/core/TypeInference.ml
@@ -606,13 +606,13 @@ let rec infer_rec ?loc ctx (t:PT.t) : T.t =
         |> List.split
       in
       let rest =
-        CCOpt.map
+        CCOption.map
           (fun s -> match Ctx.get_var_ ctx s with
              | `Var v -> v
              | `ID (id,_) -> error_ ?loc "row variable cannot be a constant %a" ID.pp id)
           rest
       in
-      let ty = T.Ty.record_flatten ty_l ~rest:(CCOpt.map Var.ty rest) in
+      let ty = T.Ty.record_flatten ty_l ~rest:(CCOption.map Var.ty rest) in
       T.record ~ty ?loc l ~rest
     | PT.AppBuiltin (Builtin.Wildcard, []) ->
       (* make a new TYPE variable *)
@@ -651,11 +651,11 @@ let rec infer_rec ?loc ctx (t:PT.t) : T.t =
       then error_ ?loc "(in)equation @[%a@] ?= @[%a@] between types is forbidden" T.pp a T.pp b;
       begin match conn with
         | Builtin.Eq ->
-          if T.Ty.is_prop (T.ty_exn a) && (CCOpt.is_none (T.head a) || CCOpt.is_none (T.head b))
+          if T.Ty.is_prop (T.ty_exn a) && (CCOption.is_none (T.head a) || CCOption.is_none (T.head b))
           then T.Form.equiv a b 
           else T.Form.eq a b
         | Builtin.Neq ->
-          if T.Ty.is_prop (T.ty_exn a) && (CCOpt.is_none (T.head a) || CCOpt.is_none (T.head b))
+          if T.Ty.is_prop (T.ty_exn a) && (CCOption.is_none (T.head a) || CCOption.is_none (T.head b))
           then T.Form.xor a b 
           else T.Form.neq a b
         | _ -> assert false

--- a/src/core/TypedSTerm.ml
+++ b/src/core/TypedSTerm.ml
@@ -140,14 +140,14 @@ let rec compare t1 t2 =
       CCOrd.list compare l1 l2
     | Record (l1, rest1), Record (l2, rest2) ->
       CCOrd.(
-        CCOpt.compare compare rest1 rest2
+        CCOption.compare compare rest1 rest2
         <?> (cmp_fields, l1, l2)
       )
     | Meta (id1,_,_), Meta (id2,_,_) -> Var.compare id1 id2
     | Ite (a1,b1,c1), Ite (a2,b2,c2) ->
       CCList.compare compare [a1;b1;c1] [a2;b2;c2]
     | Let (l1,t1), Let (l2,t2) ->
-      CCOrd.( compare t1 t2
+      CCOrd.( poly t1 t2
               <?> (list (pair Var.compare compare), l1, l2))
     | Match (u1,l1), Match (u2,l2) ->
       let cmp_branch (c1,vars1,rhs1) (c2,vars2,rhs2) =
@@ -156,7 +156,7 @@ let rec compare t1 t2 =
                <?> (list Var.compare, vars1,vars2)
                <?> (compare,rhs1,rhs2))
       in
-      CCOrd.( compare u1 u2 <?> (list cmp_branch,l1,l2))
+      CCOrd.( poly u1 u2 <?> (list cmp_branch,l1,l2))
     | Var _, _
     | Const _, _
     | App _, _
@@ -350,12 +350,12 @@ let rec check_no_dup_ seen l = match l with
     check_no_dup_ (n::seen) l'
 
 let record ?loc ~ty l ~rest =
-  let rest = CCOpt.map (var ?loc) rest in
+  let rest = CCOption.map (var ?loc) rest in
   check_no_dup_ [] l;
   make_ ?loc ~ty (Record (l,rest))
 
 let record_flatten ?loc ~ty l ~rest =
-  match CCOpt.map deref rest with
+  match CCOption.map deref rest with
   | None
   | Some {term=(Var _ | Meta _); _} ->
     let l = List.sort cmp_field l in
@@ -402,7 +402,7 @@ module Seq = struct
   let subterms t k =
     let rec iter t =
       k t;
-      CCOpt.iter iter t.ty;
+      CCOption.iter iter t.ty;
       match (deref t).term with
       | Meta _
       | Var _
@@ -410,7 +410,7 @@ module Seq = struct
       | App (f, l) -> iter f; List.iter iter l
       | Bind (_, v, t') -> iter (Var.ty v); iter t'
       | Record (l, rest) ->
-        CCOpt.iter iter rest;
+        CCOption.iter iter rest;
         List.iter (fun (_,t) -> iter t) l
       | Ite (a,b,c) -> iter a; iter b; iter c
       | Let (l,u) -> iter u; List.iter (fun (_,t) -> iter t) l
@@ -447,7 +447,7 @@ module Seq = struct
   let subterms_with_bound t k =
     let rec iter set t =
       k (t,set);
-      CCOpt.iter (iter set) t.ty;
+      CCOption.iter (iter set) t.ty;
       match view t with
       | Meta _
       | Var _
@@ -472,7 +472,7 @@ module Seq = struct
         let set' = Var.Set.add set v in
         iter set (Var.ty v); iter set' t'
       | Record (l, rest) ->
-        CCOpt.iter (iter set) rest;
+        CCOption.iter (iter set) rest;
         List.iter (fun (_,t) -> iter set t) l
       | AppBuiltin (_,l)
       | Multiset l -> List.iter (iter set) l
@@ -488,7 +488,7 @@ module Seq = struct
 end
 
 let rec is_ground t =
-  CCOpt.map_or is_ground ~default:true t.ty
+  CCOption.map_or is_ground ~default:true t.ty
   &&
   match t.term with
   | Var _ -> false
@@ -505,7 +505,7 @@ let rec is_ground t =
     List.for_all (fun (_,_,t) -> is_ground t) l
   | Bind (_, v, t') -> is_ground (Var.ty v) && is_ground t'
   | Record (l, rest) ->
-    CCOpt.map_or is_ground ~default:true rest
+    CCOption.map_or is_ground ~default:true rest
     &&
     List.for_all (fun (_,t') -> is_ground t') l
   | Multiset l -> List.for_all is_ground l
@@ -566,7 +566,7 @@ let map ~f ~bind:f_bind b_acc t = match view t with
     let ty = f b_acc (ty_exn t) in
     record_flatten ?loc:t.loc ~ty
       (List.map (CCPair.map_snd (f b_acc)) l)
-      ~rest:(CCOpt.map (f b_acc) rest)
+      ~rest:(CCOption.map (f b_acc) rest)
   | Ite (a,b,c) ->
     let a = f b_acc a in
     let b = f b_acc b in
@@ -901,7 +901,7 @@ module Form = struct
 
   let and_ ?loc l  =
     let flattened = flatten_ `And [] l in
-    let parsing = CCOpt.is_some loc in
+    let parsing = CCOption.is_some loc in
     match flattened with
     | [] when not parsing -> true_
     | [t] when not parsing -> t 
@@ -911,7 +911,7 @@ module Form = struct
 
   let or_ ?loc l = 
     let flattened = flatten_ `Or [] l in
-    let parsing = CCOpt.is_some loc in
+    let parsing = CCOption.is_some loc in
     match flattened with
     | [] when not parsing -> false_
     | [t] when not parsing -> t 
@@ -1065,8 +1065,8 @@ let rec rectify_aux ?(pref="v_") ~cnt ~subst t =
     let old = Subst.find subst v_old in
     let (_,subst,v) = handle_var ~rename:false ~pref ~cnt ~subst v_old t_ty in
     let (body, subst) = rectify_aux ~cnt ~subst body in
-    bind ~ty:t_ty b v body, (if CCOpt.is_none old then Subst.remove subst v_old
-                             else Subst.add subst v_old (CCOpt.get_exn old))
+    bind ~ty:t_ty b v body, (if CCOption.is_none old then Subst.remove subst v_old
+                             else Subst.add subst v_old (CCOption.get_exn_or "Zipper" old))
   | AppBuiltin(b, fs) ->
     let fs, subst = rec_aux_l ~cnt ~subst fs in
     app_builtin ~ty:t_ty b fs, subst
@@ -1185,7 +1185,7 @@ let occur_check_ ~allow_open ~subst v t =
   assert (is_meta v);
   let rec check bound t =
     v == t ||
-    CCOpt.map_or (check bound) ~default:false t.ty ||
+    CCOption.map_or (check bound) ~default:false t.ty ||
     match view t with
     | Meta _ -> equal v t
     | Var v' ->
@@ -1217,7 +1217,7 @@ let occur_check_ ~allow_open ~subst v t =
     | AppBuiltin (_,l)
     | Multiset l -> List.exists (check bound) l
     | Record (l, rest) ->
-      CCOpt.map_or (check bound) ~default:false rest ||
+      CCOption.map_or (check bound) ~default:false rest ||
       List.exists (fun (_,t) -> check bound t) l
   in
   check Var.Set.empty t
@@ -1573,7 +1573,7 @@ let simplify_formula t =
   let simplify_and_or t b l =
     let exists_double args =
       let pos, neg = 
-        CCList.partition_map (fun t -> 
+        CCList.partition_filter_map (fun t -> 
             match view t with 
             | AppBuiltin(Builtin.Not, [s]) -> `Right s
             | _ -> `Left t) args
@@ -1694,7 +1694,7 @@ let rec erase t = match view t with
     let u = erase u in
     STerm.let_ l u
   | Record (l, rest) ->
-    let rest = CCOpt.map
+    let rest = CCOption.map
         (fun t -> match view t with
            | Var v -> STerm.V (Var.to_string v)
            | _ -> failwith "cannot erase non-variable record raw")

--- a/src/core/Unif.ml
+++ b/src/core/Unif.ml
@@ -535,7 +535,7 @@ module Inner = struct
         let args =
           List.map
             (fun a ->
-               let i = CCList.find_idx (T.equal a) l |> CCOpt.get_exn |> fst in
+               let i = CCList.find_idx (T.equal a) l |> CCOption.get_exn_or "Zipper" |> fst in
                T.bvar ~ty:(T.ty_exn a) (n-i-1))
             inter
         in
@@ -726,7 +726,7 @@ module Inner = struct
         then fail () (* occur check or t2 is open *)
         else (
           if US.mem subst (v1,sc1) then (
-            let derefed = CCOpt.get_exn @@ Subst.get_var (US.subst subst) (v1,sc1) in 
+            let derefed = CCOption.get_exn_or "Zipper" @@ Subst.get_var (US.subst subst) (v1,sc1) in 
             let derefed = Scoped.map ((fun t -> ((Lambda.eta_reduce (Term.of_term_unsafe t)) :> InnerTerm.t))) derefed in
             if snd @@ derefed == sc2 && T.equal (fst @@ derefed) t2 then subst else fail()
           ) else US.bind subst (v1,sc1) (t2,sc2)
@@ -741,7 +741,7 @@ module Inner = struct
         then fail() (* occur check *)
         else (
           if US.mem subst (v2,sc2) then (
-            let derefed = CCOpt.get_exn @@ Subst.get_var (US.subst subst) (v2,sc2) in 
+            let derefed = CCOption.get_exn_or "Zipper" @@ Subst.get_var (US.subst subst) (v2,sc2) in 
             let derefed = Scoped.map ((fun t -> ((Lambda.eta_reduce (Term.of_term_unsafe t)) :> InnerTerm.t))) derefed in
             if snd @@ derefed == sc1 && T.equal (fst @@ derefed) t1 then subst else fail()
           ) else US.bind subst (v2,sc2) (t1,sc1)
@@ -1015,7 +1015,7 @@ module Inner = struct
         (T.var v2)
         (List.map
            (fun a ->
-              let i = CCList.find_idx (T.equal a) l1 |> CCOpt.get_exn|>fst in
+              let i = CCList.find_idx (T.equal a) l1 |> CCOption.get_exn_or "Zipper"|>fst in
               T.bvar ~ty:(T.ty_exn a) (n-i-1))
            l2)
       |> T.fun_l (List.map T.ty_exn l1)

--- a/src/core/UnifFramework.ml
+++ b/src/core/UnifFramework.ml
@@ -326,7 +326,7 @@ module Make (P : PARAMETERS) = struct
       OSeq.append 
         (try_lfho_unif t0s t1s)
         (do_unif ~bind_cnt ~hits_cnt [(lhs,rhs,P.init_flag)] subst unifscope)
-      |> OSeq.map (fun opt -> CCOpt.map (fun subst ->
+      |> OSeq.map (fun opt -> CCOption.map (fun subst ->
         let norm t = T.normalize_bools @@ Lambda.eta_expand @@ Lambda.snf t in
         let l = norm @@ S.FO.apply Subst.Renaming.none subst t0s in 
         let r = norm @@ S.FO.apply Subst.Renaming.none subst t1s in

--- a/src/core/arith/dune
+++ b/src/core/arith/dune
@@ -6,5 +6,5 @@
     (select logtk_arith.ml from
       (zarith -> logtk_arith.zarith.ml)
       (num -> logtk_arith.num.ml)))
-  (flags :standard -warn-error -a+8)
+  (flags :standard )
   )

--- a/src/core/dune
+++ b/src/core/dune
@@ -6,7 +6,7 @@
   (synopsis "core data structures and algorithms for Logtk")
   (libraries containers containers-data iter oseq
              unix mtime mtime.clock.os logtk.arith)
-  (flags :standard -w -32-50 -open Logtk_arith)
+  (flags :standard -w -a -open Logtk_arith)
   (foreign_stubs (language c) (names util_stubs) (flags :standard -Wextra -Wno-unused-parameter) )
 )
 

--- a/src/demo/resolution/dune
+++ b/src/demo/resolution/dune
@@ -1,7 +1,7 @@
 
 (executable
   (name resolution1)
-  (flags :standard -warn-error -a+8)
+  (flags :standard )
   (modes native)
   (promote (until-clean) (into ../../..))
   (libraries logtk logtk.parsers containers iter))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (env
   (_
-    (flags :standard -warn-error -3+8 -w -3 -color always -safe-string)
+    (flags :standard -w -a)
     (ocamlopt_flags :standard -O3 -unbox-closures -unbox-closures-factor 20)))
 
 (rule

--- a/src/parsers/dune
+++ b/src/parsers/dune
@@ -5,7 +5,7 @@
   (synopsis "parsers for logtk")
   (optional)
   (libraries containers logtk logtk.arith)
-  (flags :standard -warn-error -32 -open Logtk_arith)
+  (flags :standard -open Logtk_arith)
   (ocamlopt_flags :standard -Oclassic)
 )
 

--- a/src/parsers/util_tip.ml
+++ b/src/parsers/util_tip.ml
@@ -192,7 +192,7 @@ let conv_def ?loc decl body =
   UA.mk_def f ty_f [def]
 
 let convert (st:A.statement): UA.statement list =
-  let loc = CCOpt.map conv_loc st.A.loc in
+  let loc = CCOption.map conv_loc st.A.loc in
   Util.debugf 3 "@[<2>convert TIP statement@ @[%a@]@,%a@]"
     (fun k->k A.pp_stmt st ParseLocation.pp_opt loc);
   match st.A.stmt with
@@ -220,7 +220,7 @@ let convert (st:A.statement): UA.statement list =
         (fun c ->
           let args =
             c.A.cstor_args
-            |> List.map (CCPair.map CCOpt.return conv_ty) in
+            |> List.map (CCPair.map CCOption.return conv_ty) in
           c.A.cstor_name, args)
         cstors
     in
@@ -239,7 +239,7 @@ let convert (st:A.statement): UA.statement list =
                (fun c ->
                   let args =
                     c.A.cstor_args
-                    |> List.map (CCPair.map CCOpt.return conv_ty) in
+                    |> List.map (CCPair.map CCOption.return conv_ty) in
                   c.A.cstor_name, args)
                cstors
            in

--- a/src/parsers/util_tptp.ml
+++ b/src/parsers/util_tptp.ml
@@ -97,7 +97,7 @@ let _find_and_open filename dir =
 
 let parse_file ?cache ~recursive f =
   let parse_cache =
-    lazy (if recursive then CCOpt.get_lazy create_parse_cache cache
+    lazy (if recursive then CCOption.get_lazy create_parse_cache cache
           else assert false)
   in
   let dir = Filename.dirname f in

--- a/src/parsers/util_zf.ml
+++ b/src/parsers/util_zf.ml
@@ -27,7 +27,7 @@ let rec parse_lexbuf_ ?cache ?(recursive=true) ~dir lex =
   in
   if recursive
   then (
-    let cache = CCOpt.get_lazy create_parse_cache cache in
+    let cache = CCOption.get_lazy create_parse_cache cache in
     CCList.flat_map
       (fun st -> match st.A.stmt with
          | A.Include s ->

--- a/src/proofs/LLProver.ml
+++ b/src/proofs/LLProver.ml
@@ -301,7 +301,7 @@ let debug_tab out (tab:t) : unit =
 
 (* solve tableau by expanding it piece by piece *)
 let solve_ (tab:t) : res =
-  while not (CCList.is_empty tab.open_branches) && CCOpt.is_none tab.saturated do
+  while not (CCList.is_empty tab.open_branches) && CCOption.is_none tab.saturated do
     let b = List.hd tab.open_branches in
     tab.open_branches <- List.tl tab.open_branches;
     Util.debugf ~section 3

--- a/src/proofs/LLTerm.ml
+++ b/src/proofs/LLTerm.ml
@@ -302,7 +302,7 @@ let pp_inner = pp_rec_inner 0
 let subterms (t:t) (k:t -> unit) : unit =
   let rec aux t =
     k t;
-    CCOpt.iter aux (ty t);
+    CCOption.iter aux (ty t);
     begin match view t with
       | Type | Const _ | Var _ -> ()
       | App (f,a) -> aux f; aux a

--- a/src/proofs/dune
+++ b/src/proofs/dune
@@ -4,7 +4,7 @@
   (public_name logtk.proofs)
   (synopsis "proofs for logtk")
   (libraries containers logtk logtk.arith)
-  (flags :standard -w -32 -open Logtk_arith)
+  (flags :standard -open Logtk_arith)
 )
 
 

--- a/src/prover/AC.ml
+++ b/src/prover/AC.ml
@@ -301,7 +301,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
     match C.lits c with 
     | [| Literal.Equation(lhs,rhs,true) |] ->
       let ty = T.ty (T.head_term lhs) in
-      CCOpt.iter (fun id -> 
+      CCOption.iter (fun id -> 
         if not (ID.is_ac id) then (
           if ID.is_comm id then (
             if test_associativity lhs rhs || test_associativity rhs lhs then (

--- a/src/prover/Classify_cst.ml
+++ b/src/prover/Classify_cst.ml
@@ -31,7 +31,7 @@ let classify id =
       (ID.as_parameter |>> fun x->Parameter x);
       (Ind_cst.id_as_cst |>> fun c -> Inductive_cst (Some c));
       (fun id ->
-         let open CCOpt.Infix in
+         let open CCOption.Infix in
          ID.as_skolem id >>= function
          | ID.K_ind -> Some (Inductive_cst None)
          | ID.K_normal | ID.K_after_cnf | ID.K_lazy_cnf -> Some Skolem);
@@ -62,7 +62,7 @@ let pp_signature out sigma =
     "{@[<hv>%a@]}" (Util.pp_list ~sep:"," pp_pair) (Signature.to_list sigma)
 
 let dominates_ opt_c opt_sub =
-  CCOpt.(get_or ~default:false (map2 Ind_cst.dominates opt_c opt_sub))
+  CCOption.(get_or ~default:false (map2 Ind_cst.dominates opt_c opt_sub))
 
 let prec_constr_ a b =
   let to_int_ = function

--- a/src/prover/Cut_form.ml
+++ b/src/prover/Cut_form.ml
@@ -260,7 +260,7 @@ module FV_tbl(X : Map.OrderedType) = struct
     |> Iter.find_map
       (fun (k',v) -> if are_variant k k' then Some v else None)
 
-  let mem t k = get t k |> CCOpt.is_some
+  let mem t k = get t k |> CCOption.is_some
 
   let to_iter t = FV.iter t.fv
 end

--- a/src/prover/Ind_cst.ml
+++ b/src/prover/Ind_cst.ml
@@ -73,7 +73,7 @@ let id_is_cst id = match id_as_cst id with Some _ -> true | _ -> false
 
 let is_sub c = c.cst_is_sub
 
-let id_is_sub id = id_as_cst id |> CCOpt.map_or ~default:false is_sub
+let id_is_sub id = id_as_cst id |> CCOption.map_or ~default:false is_sub
 
 (** {5 Creation of Coverset and Cst} *)
 

--- a/src/prover/bBox.ml
+++ b/src/prover/bBox.ml
@@ -146,7 +146,7 @@ let find_boolean_lit lits =
         (* assert (_check_variant lits lits'); *)
         Some blit
       | _ -> None)
-  |> CCOpt.map (fun t -> Lit.apply_sign sign t)
+  |> CCOption.map (fun t -> Lit.apply_sign sign t)
 
 (* clause -> boolean lit *)
 let inject_lits_ lits  =
@@ -178,7 +178,7 @@ let inject_lit lit =
   in
 
   try 
-    CCOpt.return @@
+    CCOption.return @@
       begin match Term.Tbl.find_opt _term_set (lit_to_term lit) with
       | Some t -> Lit.apply_sign (Literal.is_positivoid lit) t
       | None ->

--- a/src/prover/bool_selection.ml
+++ b/src/prover/bool_selection.ml
@@ -70,7 +70,7 @@ let get_forbidden_vars ~ord lits =
     ) T.VarSet.empty
 
 let select_leftmost ~ord ~kind lits =
-  let open CCOpt in
+  let open CCOption in
   let forbidden = get_forbidden_vars ~ord lits in
 
   let rec aux_lits idx =
@@ -95,7 +95,7 @@ let select_leftmost ~ord ~kind lits =
   and aux_term ~top ~pos_builder t =
     (* if t is app_var then return the term itself, but do not recurse  *)
     if T.is_app_var t then (
-      CCOpt.return_if (is_selectable ~top ~forbidden t) (t, PB.to_pos pos_builder)
+      CCOption.return_if (is_selectable ~top ~forbidden t) (t, PB.to_pos pos_builder)
     ) else (
       match T.view t with
       | T.App(_, args)
@@ -119,7 +119,7 @@ let select_leftmost ~ord ~kind lits =
       <+>
     (aux_term_args ~idx:(idx-1) ~pos_builder xs) 
   in
-  CCOpt.map_or ~default:[] (fun x -> [x]) (aux_lits 0)
+  CCOption.map_or ~default:[] (fun x -> [x]) (aux_lits 0)
 
 let collect_green_subterms_ ~forbidden ~filter ~ord ~pos_builder t k = 
   let rec aux_term ~top ~pos_builder t k =
@@ -165,7 +165,7 @@ let all_eligible_subterms ~ord ~pos_builder =
   collect_green_subterms_ ~forbidden:(T.VarSet.empty) ~filter ~ord ~pos_builder 
 
 let get_selectable_w_ctx ~ord lits = 
-  let open CCOpt in
+  let open CCOption in
   let forbidden = get_forbidden_vars ~ord lits in
 
   let selectable_with_ctx ?(forbidden=T.VarSet.empty) ~block_top ~ord ~pos_builder t ctx log_depth k =
@@ -252,7 +252,7 @@ let by_size ~ord ~kind lits =
     if kind = `Max then Iter.max else Iter.min in
   get_selectable_w_ctx ~ord lits
   |> selector ~lt:(fun (s,_,_) (t,_,_) -> Term.ho_weight s < Term.ho_weight t)
-  |> CCOpt.map_or ~default:[] (fun (t,ctx,pos) -> [(t,pos)])
+  |> CCOption.map_or ~default:[] (fun (t,ctx,pos) -> [(t,pos)])
 
 let by_context_weight_combination ~ord ~ctx_fun ~weight_fun lits =
     let bin_of_int d =
@@ -270,7 +270,7 @@ let by_context_weight_combination ~ord ~ctx_fun ~weight_fun lits =
     Util.debugf ~section 2 "selectable @[%a/%8s@]@." (fun k -> k T.pp t (bin_of_int ctx)); arg)
   |> Iter.min ~lt:(fun (s,ctx_s,_) (t,ctx_t,_) -> 
     CCOrd.(<?>) (ctx_fun ctx_s ctx_t) (weight_fun lits, s, t) < 0)
-  |> CCOpt.map_or ~default:[] (fun (t,ctx,pos) -> [(t,pos)])
+  |> CCOption.map_or ~default:[] (fun (t,ctx,pos) -> [(t,pos)])
 
 let is_eq t = 
   match T.view t with
@@ -392,7 +392,7 @@ let parse_combined_function ~ord s =
     Str.regexp ("sel\\([1-3]\\)(\\(.+\\))") in
     try
       ignore(Str.search_forward or_lmax_regex s 0);
-      let sel_id = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
+      let sel_id = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
       let ctx_fun_name = Str.matched_group 2 s in
 
       let weight_fun = List.nth sel_funs (sel_id-1) in

--- a/src/prover/clause.ml
+++ b/src/prover/clause.ml
@@ -104,7 +104,7 @@ module Make(Ctx : Ctx.S) : S with module Ctx = Ctx = struct
   let is_goal c = Proof.Step.is_goal c.proof
 
   let distance_to_goal c = Proof.Step.distance_to_goal c.proof
-  let comes_from_goal c = CCOpt.is_some @@ distance_to_goal c
+  let comes_from_goal c = CCOption.is_some @@ distance_to_goal c
 
   (* private function for building clauses *)
   let create_inner ~penalty ~selected ~bool_selected sclause proof =
@@ -439,11 +439,11 @@ module Make(Ctx : Ctx.S) : S with module Ctx = Ctx = struct
 
   let apply_subst ?(renaming) ?(proof=None) ?(penalty_inc=None) (c,sc) subst =
     let lits = lits c in
-    let renaming = CCOpt.get_or ~default:(S.Renaming.create ()) renaming in
+    let renaming = CCOption.get_or ~default:(S.Renaming.create ()) renaming in
     let new_lits = Literals.apply_subst renaming  subst (lits, sc) in
-    let proof_step = CCOpt.get_or ~default:(proof_step c) proof in
+    let proof_step = CCOption.get_or ~default:(proof_step c) proof in
     (* increase can be negative if we perform a simplification *)
-    let penalty = max ((CCOpt.get_or ~default:0 penalty_inc) + (penalty c)) 1 in
+    let penalty = max ((CCOption.get_or ~default:0 penalty_inc) + (penalty c)) 1 in
     create ~trail:(trail c) ~penalty (CCArray.to_list new_lits) proof_step
 
 

--- a/src/prover/clauseQueue.ml
+++ b/src/prover/clauseQueue.ml
@@ -54,10 +54,10 @@ let profile_of_string s =
         in
         let par_mag = List.nth args 2 in
         let goal_pen = List.nth args 3 in
-        if CCOpt.is_none ratio then (
+        if CCOption.is_none ratio then (
           invalid_arg err_msg;
         ) else (
-          cr_var_ratio := CCOpt.get_exn ratio;
+          cr_var_ratio := CCOption.get_exn_or "Zipper" ratio;
           cr_var_mul := var_mul;
           parameters_magnitude := if CCString.equal par_mag "l" then `Large
             else if CCString.equal par_mag "s" then `Small
@@ -152,7 +152,7 @@ module Make(C : Clause_intf.S) = struct
         |> Iter.map Term.ty
         |> Iter.map Type.depth
         |> Iter.max ?lt:None
-        |> CCOpt.map_or CCFun.id ~default:0
+        |> CCOption.map_or CCFun.id ~default:0
       in
       let w_lits = weight_lits_ (C.lits c) in
       w_lits * Array.length (C.lits c) + _depth_ty
@@ -177,7 +177,7 @@ module Make(C : Clause_intf.S) = struct
       let t_depth c = C.Seq.terms c
                       |> Iter.map Term.depth
                       |> Iter.max
-                      |> CCOpt.get_or ~default:0
+                      |> CCOption.get_or ~default:0
                       |> float_of_int in
 
       let weight c = float_of_int (weight_lits_ (C.lits c)) in
@@ -678,8 +678,8 @@ module Make(C : Clause_intf.S) = struct
       try
         ignore(Str.search_forward crv_regex s 0);
         
-        let sym_w = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 1 s) in
-        let var_w = CCOpt.get_exn @@ CCInt.of_string (Str.matched_group 2 s) in
+        let sym_w = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 1 s) in
+        let var_w = CCOption.get_exn_or "Zipper" @@ CCInt.of_string (Str.matched_group 2 s) in
         let max_t_mul = CCFloat.of_string_exn (Str.matched_group 3 s) in
         let max_l_mul = CCFloat.of_string_exn (Str.matched_group 4 s) in
         let pos_mul = CCFloat.of_string_exn (Str.matched_group 5 s) in
@@ -720,10 +720,10 @@ module Make(C : Clause_intf.S) = struct
       try
         ignore(Str.search_forward crv_regex s 0);
         let parse_bool s = CCString.prefix ~pre:"t" (String.lowercase_ascii s) in
-        let fweight = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 1 s) in
-        let vweight = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 2 s) in
+        let fweight = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 1 s) in
+        let vweight = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 2 s) in
         let pos_multiplier = CCFloat.of_string_exn (Str.matched_group 3 s) in
-        let dup_weight = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 4 s) in
+        let dup_weight = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 4 s) in
         let pos_use_dag = parse_bool @@ Str.matched_group 5 s in
         let pos_t_reset = parse_bool @@ Str.matched_group 6 s in
         let pos_eqn_reset = parse_bool @@ Str.matched_group 7 s in
@@ -748,10 +748,10 @@ module Make(C : Clause_intf.S) = struct
         ignore(Str.search_forward crv_regex s 0);
         let conj_mul = CCFloat.of_string_exn (Str.matched_group 1 s) in
         let fresh_mul = CCFloat.of_string_exn (Str.matched_group 2 s) in
-        let f = CCOpt.get_exn @@ CCInt.of_string (Str.matched_group 3 s) in
-        let cst = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 4 s) in
-        let p = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 5 s) in
-        let v = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 6 s) in
+        let f = CCOption.get_exn_or "Zipper" @@ CCInt.of_string (Str.matched_group 3 s) in
+        let cst = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 4 s) in
+        let p = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 5 s) in
+        let v = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 6 s) in
         let max_term_mul = CCFloat.of_string_exn (Str.matched_group 7 s) in
         let max_lit_mul = CCFloat.of_string_exn (Str.matched_group 8 s) in
         let pos_mul = CCFloat.of_string_exn (Str.matched_group 9 s) in
@@ -770,8 +770,8 @@ module Make(C : Clause_intf.S) = struct
         ignore(Str.search_forward crs_regex s 0);
         let inst_penalty = CCFloat.of_string_exn (Str.matched_group 1 s) in
         let gen_penalty = CCFloat.of_string_exn (Str.matched_group 2 s) in
-        let var_w = CCOpt.get_exn @@ CCInt.of_string (Str.matched_group 3 s) in
-        let sym_w = CCOpt.get_exn @@  CCInt.of_string (Str.matched_group 4 s) in
+        let var_w = CCOption.get_exn_or "Zipper" @@ CCInt.of_string (Str.matched_group 3 s) in
+        let sym_w = CCOption.get_exn_or "Zipper" @@  CCInt.of_string (Str.matched_group 4 s) in
         conj_relative_struct ~inst_penalty ~gen_penalty ~var_w ~sym_w
       with Not_found | Invalid_argument _ ->
         invalid_arg
@@ -787,8 +787,8 @@ module Make(C : Clause_intf.S) = struct
            ^ "\\([0-9]+[.]?[0-9]*\\))") in
       try
         ignore(Str.search_forward or_lmax_regex s 0);
-        let v_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
-        let f_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 2 s)) in
+        let v_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
+        let f_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 2 s)) in
         let pos_m = CCFloat.of_string_exn (Str.matched_group 3 s) in
         let unord_m = CCFloat.of_string_exn (Str.matched_group 4 s) in
         let max_l_mul = CCFloat.of_string_exn (Str.matched_group 5 s) in
@@ -811,10 +811,10 @@ module Make(C : Clause_intf.S) = struct
            ^ "\\([0-9]+[.]?[0-9]*\\))") in
       try
         ignore(Str.search_forward or_lmax_regex s 0);
-        let pf_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
-        let pv_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 2 s)) in
-        let nf_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 3 s)) in
-        let nv_w = CCOpt.get_exn (CCInt.of_string (Str.matched_group 4 s)) in
+        let pf_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
+        let pv_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 2 s)) in
+        let nf_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 3 s)) in
+        let nv_w = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 4 s)) in
         let max_t_m = CCFloat.of_string_exn (Str.matched_group 5 s) in
         let max_l_m = CCFloat.of_string_exn (Str.matched_group 6 s) in
         let pos_m = CCFloat.of_string_exn (Str.matched_group 7 s) in
@@ -902,11 +902,11 @@ module Make(C : Clause_intf.S) = struct
         let l_poly_const = CCFloat.of_string_exn (Str.matched_group 1 s) in
         let l_poly_lin = CCFloat.of_string_exn (Str.matched_group 2 s) in
         let l_poly_sq = CCFloat.of_string_exn (Str.matched_group 3 s) in
-        let def_l = CCOpt.get_exn (CCInt.of_string (Str.matched_group 4 s)) in
-        let fw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 5 s)) in
-        let cw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 6 s)) in
-        let pw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 7 s)) in
-        let vw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 8 s)) in
+        let def_l = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 4 s)) in
+        let fw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 5 s)) in
+        let cw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 6 s)) in
+        let pw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 7 s)) in
+        let vw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 8 s)) in
         let max_t_mul = CCFloat.of_string_exn (Str.matched_group 9 s) in
         let max_lit_mul = CCFloat.of_string_exn (Str.matched_group 10 s) in
         let pos_lit_mul = CCFloat.of_string_exn (Str.matched_group 11 s) in
@@ -1011,8 +1011,8 @@ module Make(C : Clause_intf.S) = struct
           ("clauseweight(\\([0-9]+\\),\\([0-9]+\\),\\([0-9]+[.]?[0-9]*\\)") in
       try
         ignore(Str.search_forward or_lmax_regex s 0);
-        let fw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
-        let vw = CCOpt.get_exn (CCInt.of_string (Str.matched_group 2 s)) in
+        let fw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
+        let vw = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 2 s)) in
         let pos_lit_mul = CCFloat.of_string_exn (Str.matched_group 3 s) in
         clauseweight ~fw ~vw ~pos_lit_mul
       with Not_found | Invalid_argument _ ->
@@ -1042,8 +1042,8 @@ module Make(C : Clause_intf.S) = struct
            ^ "\\([0-9]+[.]?[0-9]*\\))") in
       try
         ignore(Str.search_forward or_lmax_regex s 0);
-        let v = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
-        let f = CCOpt.get_exn (CCInt.of_string (Str.matched_group 2 s)) in
+        let v = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
+        let f = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 2 s)) in
         let pos_mul = CCFloat.of_string_exn (Str.matched_group 3 s) in
         let conj_mul = CCFloat.of_string_exn (Str.matched_group 4 s) in
         let dist_var_mul = CCFloat.of_string_exn (Str.matched_group 5 s) in
@@ -1096,7 +1096,7 @@ module Make(C : Clause_intf.S) = struct
     let prefer_ho_steps c = if Proof.Step.has_ho_step (C.proof_step c) then 0 else 1
 
     let prefer_sos c =
-      if C.proof_depth c = 0 || CCOpt.is_some (C.distance_to_goal c) then 0 else 1
+      if C.proof_depth c = 0 || CCOption.is_some (C.distance_to_goal c) then 0 else 1
 
     let prefer_non_goals c =
       if Iter.exists Literal.is_positivoid (C.Seq.lits c) then 0 else 1
@@ -1138,7 +1138,7 @@ module Make(C : Clause_intf.S) = struct
           ) else max_int
         | _ -> max_int)
       |> Iter.min
-      |> CCOpt.get_or ~default:0
+      |> CCOption.get_or ~default:0
 
     let prefer_easy_ho c =
       let is_arg_cong_child c =
@@ -1235,7 +1235,7 @@ module Make(C : Clause_intf.S) = struct
       if C.is_ground c then 1 else 0
 
     let defer_sos c = 
-      if C.proof_depth c = 0 || CCOpt.is_some (C.distance_to_goal c) then 1 else 0
+      if C.proof_depth c = 0 || CCOption.is_some (C.distance_to_goal c) then 1 else 0
 
     let prefer_top_level_app_var c =
       let lits = C.lits c in
@@ -1271,7 +1271,7 @@ module Make(C : Clause_intf.S) = struct
       C.Seq.terms c
       |> Iter.map app_var_depth
       |> Iter.max
-      |> CCOpt.get_or ~default:min_int
+      |> CCOption.get_or ~default:min_int
 
     let by_app_var_num c =
       C.Seq.terms c
@@ -1308,8 +1308,8 @@ module Make(C : Clause_intf.S) = struct
 
       C.Seq.terms c
       |> Iter.fold (fun acc t -> max_opt acc (depth_fun t)) None
-      |> CCOpt.map modifier
-      |> CCOpt.get_or ~default:max_int
+      |> CCOption.map modifier
+      |> CCOption.get_or ~default:max_int
 
     
     let prefer_shallow_lambdas c = 
@@ -1326,7 +1326,7 @@ module Make(C : Clause_intf.S) = struct
       Literals.Seq.terms (C.lits c)
       |> Iter.map Term.depth
       |> Iter.max
-      |> CCOpt.get_or ~default:0
+      |> CCOption.get_or ~default:0
 
     let defer_shallow c =
       - (prefer_shallow c)
@@ -1713,7 +1713,7 @@ let parse_wf_with_priority s =
   let wf_with_prio_regex = Str.regexp "\\([0-9]+\\)|\\(.+\\)|\\(.+\\)" in
   try
     ignore(Str.search_forward wf_with_prio_regex s 0);
-    let ratio = CCOpt.get_exn (CCInt.of_string (Str.matched_group 1 s)) in
+    let ratio = CCOption.get_exn_or "Zipper" (CCInt.of_string (Str.matched_group 1 s)) in
     let priority_str = CCString.trim (Str.matched_group 2 s) in
     let weight_fun = CCString.trim (Str.matched_group 3 s) in
     funs_to_parse := !funs_to_parse @ [(ratio, priority_str, weight_fun)]

--- a/src/prover/combinators.ml
+++ b/src/prover/combinators.ml
@@ -285,7 +285,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         let n = List.length ty_args in
         let bvars = List.mapi (fun i ty -> T.bvar ~ty (n-i-1)) ty_args in
         let t' = T.app t bvars in
-        let body = CCOpt.get_or ~default:t' (comb_normalize t') in
+        let body = CCOption.get_or ~default:t' (comb_normalize t') in
         T.fun_l ty_args body
       ) else Lambda.eta_expand t
     

--- a/src/prover/combinators_base.mli
+++ b/src/prover/combinators_base.mli
@@ -14,7 +14,7 @@ val curry_optimizations: (Term.t -> Term.t option) list
 val narrow_rules: (Term.t -> Term.t option) list
 val abf : rules:(Term.t -> Term.t option) list -> Logtk.Lambda.term -> Term.t
 val comb2lam : Term.t -> Term.t
-val comb_normalize : Term.t -> Term.t CCOpt.t
+val comb_normalize : Term.t -> Term.t CCOption.t
 val cmp_by_max_weak_r_len :
   Term.t -> Term.t -> Logtk.Comparison.t * Term.t * Term.t
 

--- a/src/prover/dune
+++ b/src/prover/dune
@@ -13,4 +13,4 @@
   (public_name libzipperposition)
   (synopsis "library for the Zipperposition theorem prover")
   (libraries containers msat logtk logtk.arith logtk.proofs logtk.parsers str)
-  (flags :standard -w -32-50 -open Logtk_arith))
+  (flags :standard -w -a -open Logtk_arith))

--- a/src/prover/env.ml
+++ b/src/prover/env.ml
@@ -164,7 +164,7 @@ module Make(X : sig
     match !_queue with
     | None ->
       _queue := Some (StmQ.default ());
-      CCOpt.get_exn (!_queue);
+      CCOption.get_exn_or "Zipper" (!_queue);
     | Some q -> q 
 
   let add_empty c =
@@ -643,7 +643,7 @@ module Make(X : sig
     let depth_map = 
       ref (Util.Int_map.singleton (C.id c) depth) in
     let [@inline] get_depth c =
-      CCOpt.get_exn @@ Util.Int_map.get (C.id c) !depth_map in
+      CCOption.get_exn_or "Zipper" @@ Util.Int_map.get (C.id c) !depth_map in
     let [@inline] update_map c c' = 
       let d = get_depth c in
       depth_map := 
@@ -806,7 +806,7 @@ module Make(X : sig
       match rules with
       | [] -> None
       | r :: rs ->
-        CCOpt.or_lazy ~else_:(fun () -> apply_rules ~rules:rs c) (r c) in
+        CCOption.or_lazy ~else_:(fun () -> apply_rules ~rules:rs c) (r c) in
     
     let q = Queue.create () in
     Queue.add c q;

--- a/src/prover/eprover_interface.ml
+++ b/src/prover/eprover_interface.ml
@@ -207,7 +207,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                 flush_all ();
                 if Str.string_match reg_thf_clause line 0 then (
                   let id = CCInt.of_string (Str.matched_group 1 line) in
-                  clause_ids := CCOpt.get_exn id :: !clause_ids;)
+                  clause_ids := CCOption.get_exn_or "Zipper" id :: !clause_ids;)
                 else if Str.string_match regex_refutation_end line 0 then (
                   raise End_of_file
                 )
@@ -228,16 +228,16 @@ module Make(E : Env.S) : S with module Env = E = struct
       let lambda_limit = 6 in
       C.Seq.terms c
       |> Iter.map (fun t -> 
-          CCOpt.get_or ~default:0 (Term.lambda_depth t))
+          CCOption.get_or ~default:0 (Term.lambda_depth t))
       |> Iter.max
-      |> CCOpt.get_or ~default:0
+      |> CCOption.get_or ~default:0
       |> (fun lam_depth -> lam_depth > lambda_limit) 
     in
 
     let convert_clauses ~converter ~encoded_symbols iter =
       let converted = 
         Iter.map (fun c -> 
-          CCOpt.get_or ~default:c (C.eta_reduce c)) iter
+          CCOption.get_or ~default:c (C.eta_reduce c)) iter
         |> Iter.flat_map_l converter in
 
       let encoded, encoded_symbols = 
@@ -303,7 +303,7 @@ module Make(E : Env.S) : S with module Env = E = struct
               List.find (fun cl -> (C.id cl) = id) cl_set) ids in
           let rule = Proof.Rule.mk "eprover" in
           let proof = Proof.Step.inference  ~rule (List.map C.proof_parent clauses) in
-          let penalty = CCOpt.get_exn @@ Iter.max (Iter.map C.penalty (Iter.of_list clauses)) in
+          let penalty = CCOption.get_exn_or "Zipper" @@ Iter.max (Iter.map C.penalty (Iter.of_list clauses)) in
           let trail = C.trail_l clauses in
           Some (C.create ~penalty ~trail [] proof)
         | _ -> None 

--- a/src/prover/lift_lambdas.ml
+++ b/src/prover/lift_lambdas.ml
@@ -195,7 +195,7 @@ let lift_lambdas_t ~parent ~counter t  =
   let lift_lambdas cl =
     let counter = 
       ref ((C.Seq.vars cl |> Iter.map HVar.id 
-            |> Iter.max |> CCOpt.get_or ~default:0) + 1) in
+            |> Iter.max |> CCOption.get_or ~default:0) + 1) in
     let lits, (reused_defs, new_defs) = 
       C.lits cl
       |> CCArray.to_list
@@ -234,7 +234,7 @@ let lift_lambdas_t ~parent ~counter t  =
   
   let lift_lambdas_cnf st =
     Env.cr_return @@ CCList.flat_map (fun c -> 
-      CCOpt.get_or ~default:[c] (lift_lambdas_simp c)
+      CCOption.get_or ~default:[c] (lift_lambdas_simp c)
     )(E.C.of_statement st)
 
   let setup () =

--- a/src/prover/saturate.ml
+++ b/src/prover/saturate.ml
@@ -29,7 +29,7 @@ let e_path = ref (None : string option)
 let tried_e = ref false 
 let e_call_point = ref 0.2
 let should_try_e = function
-  | Some timeout when CCOpt.is_some !e_path -> 
+  | Some timeout when CCOption.is_some !e_path -> 
     let passed = Util.total_time_s () in
     if not !tried_e && passed > !e_call_point *. timeout then (
       tried_e := true;
@@ -240,7 +240,7 @@ module Make(E : Env.S) = struct
             let inferred_clauses =
               (* After forward simplification, do cheap multi simplification like AVATAR *)
               Iter.flat_map_l (fun c -> 
-                CCOpt.get_or ~default:[c] (Env.cheap_multi_simplify c)
+                CCOption.get_or ~default:[c] (Env.cheap_multi_simplify c)
               ) inferred_clauses in
             CCVector.append_iter new_clauses inferred_clauses;
             Util.debugf ~section 2 "@[<2>inferred @{<green>new clauses@}:@ [@[<v>%a@]]@]"
@@ -260,8 +260,8 @@ module Make(E : Env.S) = struct
       end
 
   let given_clause ?(generating=true) ?steps ?timeout () =
-    if CCOpt.is_some !e_path then (
-      EInterface.set_e_bin (CCOpt.get_exn !e_path)
+    if CCOption.is_some !e_path then (
+      EInterface.set_e_bin (CCOption.get_exn_or "Zipper" !e_path)
     );
 
     (* num: number of steps done so far *)

--- a/src/prover/selection.ml
+++ b/src/prover/selection.ml
@@ -500,7 +500,7 @@ let e_sel14 ~blocker ~ord lits =
   weight_based_sel_driver ~can_sel:can_select_lit ~ord lits chooser ~blocker:(blocker blocked)
 
 let e_sel15 ~blocker ~ord lits =
-  let (<+>) = CCOpt.Infix.(<+>)  in
+  let (<+>) = CCOption.Infix.(<+>)  in
   let lits_l = CCList.mapi (fun i l -> (i,l)) (CCArray.to_list lits) in
   let sel_bv = CCBV.create ~size:(CCArray.length lits) false in
   let res = 
@@ -520,7 +520,7 @@ let e_sel15 ~blocker ~ord lits =
           ) else None)
      |> CCList.to_iter
      |> Iter.min ~lt:(fun (_, w1) (_, w2) -> w1 < w2)
-     |> CCOpt.map (fun (i,_) -> CCBV.set sel_bv i; sel_bv))
+     |> CCOption.map (fun (i,_) -> CCBV.set sel_bv i; sel_bv))
   <+>
     (* else if there is a _single_ maximal positive literal,
        do not select anything *)
@@ -533,7 +533,7 @@ let e_sel15 ~blocker ~ord lits =
   <+>
     (* else behave as SelectNewComplexAHPNS  *)
     Some (e_sel14 ~blocker ~ord lits) in
-  CCOpt.get_exn res
+  CCOption.get_exn_or "Zipper" res
   |> (fun res_bv -> 
         let block_bv = 
           CCBV.create ~size:(CCArray.length lits) true in

--- a/src/prover/stream.ml
+++ b/src/prover/stream.ml
@@ -85,8 +85,8 @@ module Make(A:ARG) = struct
           let cl_p = (clause_penalty s hd) in
           s.penalty <-  s.penalty + cl_p;
           hd) in
-    if CCOpt.is_some res then 
-      Util.debugf ~section 1 "drip:%d/%d->@[%a@]:@. @[%a@]@." (fun k -> k orig_penalty s.hits pp s (CCOpt.pp C.pp) res);
+    if CCOption.is_some res then 
+      Util.debugf ~section 1 "drip:%d/%d->@[%a@]:@. @[%a@]@." (fun k -> k orig_penalty s.hits pp s (CCOption.pp C.pp) res);
     res
 
   let drip_n s n guard =
@@ -128,7 +128,7 @@ module Make(A:ARG) = struct
         s.stm <- OSeq.empty;
         s.penalty <- s.penalty + p_add;
         raise (Drip_n_Unfinished (res,p_add,n')) in
-    Util.debugf ~section 1 "drip_n:%d->@[%a@]:@. @[%a@]@." (fun k -> k orig_penalty pp s (CCList.pp (CCOpt.pp C.pp)) res);
+    Util.debugf ~section 1 "drip_n:%d->@[%a@]:@. @[%a@]@." (fun k -> k orig_penalty pp s (CCList.pp (CCOption.pp C.pp)) res);
     res
 
 end

--- a/src/prover/streamQueue.ml
+++ b/src/prover/streamQueue.ml
@@ -140,7 +140,7 @@ module Make(A : ARG) = struct
         | (_,s) :: s_rest ->
           match Stm.drip s with
           | result ->
-            let n = n + (if CCOpt.is_some result then 1 else 0) in
+            let n = n + (if CCOption.is_some result then 1 else 0) in
             let limit_reached = (*get_op k_clause_num > 0 && n < get_op k_clause_num*) false in
             if (is_empty_clause result) || (full && limit_reached) 
             then List.rev_append ((result,s) :: acc) (CCList.rev_map (fun (_,s) -> None, s) s_rest)
@@ -153,7 +153,7 @@ module Make(A : ARG) = struct
     q.hp <- H.of_list new_stms;
     q.stm_nb <- List.length new_stms;
     let taken = List.rev_map fst dripped in
-    Util.debugf ~section 1 "taken clauses: @[%a@]@." (fun k -> k (CCList.pp (CCOpt.pp Stm.C.pp)) taken);
+    Util.debugf ~section 1 "taken clauses: @[%a@]@." (fun k -> k (CCList.pp (CCOption.pp Stm.C.pp)) taken);
     taken
 
 
@@ -164,7 +164,7 @@ module Make(A : ARG) = struct
       if CCList.is_empty res then take_fair_anyway q
       else (
         q.time_before_fair <- q.ratio;
-        List.rev_map CCOpt.return res)
+        List.rev_map CCOption.return res)
     )
     
   let rec _take_nb q nb prev_res =

--- a/src/prover_calculi/Higher_order.ml
+++ b/src/prover_calculi/Higher_order.ml
@@ -946,7 +946,7 @@ module Make(E : Env.S) : S with module Env = E = struct
              end)
           ([], [], [])
           (C.lits c)
-        |> CCOpt.return
+        |> CCOption.return
       with Exit -> None
     in
     (* try to eliminate [v], if it doesn't occur in its own arguments *)
@@ -958,7 +958,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         | Some (other_lits, constr_l, pos_lits) ->
           (* gather positive/negative args *)
           let pos_args, neg_args =
-            CCList.partition_map
+            CCList.partition_filter_map
               (fun (args,sign) -> if sign then `Left args else `Right args)
               constr_l
           in
@@ -1032,7 +1032,7 @@ module Make(E : Env.S) : S with module Env = E = struct
             | T.Var x -> Some x
             | T.App(hd, _) when T.is_var hd ->  Some (T.as_var_exn hd)
             | _ -> None in
-          CCOpt.to_list (extract_var l) @ CCOpt.to_list (extract_var r))
+          CCOption.to_list (extract_var l) @ CCOption.to_list (extract_var r))
       |> Iter.filter (fun v -> Type.returns_prop @@ HVar.ty v)
       |> T.VarSet.of_iter (* unique *)
     in
@@ -1086,7 +1086,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let insantiate_choice ?(proof_constructor=Proof.Step.inference) ?(inst_vars=true) ?(choice_ops=choice_ops) c =
     let max_var = 
       ref ((C.Seq.vars c |> Iter.map HVar.id
-            |> Iter.max |> CCOpt.get_or ~default: 0) + 1) in
+            |> Iter.max |> CCOption.get_or ~default: 0) + 1) in
 
     let is_choice_subterm t =
       match T.view t with
@@ -1377,7 +1377,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let elim_andrews_equality_simpls c =
     if C.proof_depth c < Env.flex_get k_elim_andrews_eq then (
       let res = elim_andrews_eq_ c in
-      CCOpt.return_if (not (CCList.is_empty res)) res
+      CCOption.return_if (not (CCList.is_empty res)) res
     ) else None
   
 
@@ -1433,7 +1433,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let pairs, others =
         C.lits c
         |> Array.to_list
-        |> CCList.partition_map
+        |> CCList.partition_filter_map
           (function
             | Literal.Equation (t,u, false) as lit
               when Literal.is_ho_constraint lit -> `Left ([],t,u)
@@ -1591,7 +1591,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       if condition then raise Fail in
 
     let find_in_args var args =
-      fst @@ CCOpt.get_or ~default:(-1, T.true_)
+      fst @@ CCOption.get_or ~default:(-1, T.true_)
         (CCList.find_idx (T.equal var) args) in
 
     try 
@@ -1739,7 +1739,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                     List.hd new_cl
                 ) in
               let first_two, rest = 
-                OSeq.take 2 res, OSeq.map CCOpt.return (OSeq.drop 2 res) in
+                OSeq.take 2 res, OSeq.map CCOption.return (OSeq.drop 2 res) in
               let stm =  Stm.make ~penalty:(C.penalty c + 20) ~parents:[c] rest in
               StmQ.add (Env.get_stm_queue ()) stm;
               
@@ -2040,7 +2040,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         if not (ID.Set.is_empty ids) then List.map (Term.const ~ty) (ID.Set.to_list ids)
         else [Type.Tbl.get_or_add groundings ~f:introduce_new_const ~k:ty] 
     in
-    CCOpt.map (fun v ->
+    CCOption.map (fun v ->
       let inst repl =
         assert (T.is_ground repl);
         let subst = Subst.FO.bind' Subst.empty (v,0) (repl,0) in

--- a/src/prover_calculi/Rewriting.ml
+++ b/src/prover_calculi/Rewriting.ml
@@ -257,7 +257,7 @@ module Make(E : Env_intf.S) = struct
                "(@[<2>ctx_narrow@ :rule %a[%d]@ :clause %a[%d]@ :pos %a@ :subst %a@ :yield %a@])"
                (fun k->k RW.Rule.pp rule sc_p C.pp c sc_a P.pp rule_pos Subst.pp subst C.pp new_c);
              new_c)
-        |> CCOpt.return
+        |> CCOption.return
     in
     ctx_narrow_find (s,sc_a) sc_p
     |> Iter.fold
@@ -331,23 +331,23 @@ let rewrite_tst_stmt stmt =
     let ctx = Type.Conv.create () in
     let t = Term.Conv.of_simple_term_exn ctx f in
     let snf = Lambda.snf in
-    CCOpt.map (fun (t',p) ->  (Term.Conv.to_simple_term ctx (snf t'), p)) (simpl_term t) in
+    CCOption.map (fun (t',p) ->  (Term.Conv.to_simple_term ctx (snf t'), p)) (simpl_term t) in
 
   let aux_l fs =
     let ts = List.map aux fs in
-    if List.for_all CCOpt.is_none ts then None
+    if List.for_all CCOption.is_none ts then None
     else (
       let proof = ref [] in
       let combined = CCList.combine fs ts in
       let res = 
         List.map (fun (f,res) -> 
-            let f', p_list = CCOpt.get_or ~default:(f,[]) res in
+            let f', p_list = CCOption.get_or ~default:(f,[]) res in
             proof := p_list @ !proof;
             f') combined in
       Some (res, !proof)) in
 
   let mk_proof ~stmt_parents f_opt orig =
-    CCOpt.map (fun (f', parent_list) -> 
+    CCOption.map (fun (f', parent_list) -> 
         let rule = Proof.Rule.mk "definition expansion" in
         f', Proof.S.mk_f_simp ~rule orig (parent_list @ stmt_parents)) f_opt in
 

--- a/src/prover_calculi/app_encode.ml
+++ b/src/prover_calculi/app_encode.ml
@@ -97,7 +97,7 @@ let app_encode_var var =
 let rec app_encode_term toplevel t  =
   if toplevel then Util.debugf ~section 3 "Encoding toplevel term @[%a@]" (fun k -> k T.pp t);
 
-  let ty = app_encode_ty (CCOpt.get_exn (T.ty t)) in
+  let ty = app_encode_ty (CCOption.get_exn_or "Zipper" (T.ty t)) in
   let t' = match T.view t with
     | T.App (f, []) -> app_encode_term false f
     | T.App (f, args) ->
@@ -114,7 +114,7 @@ let rec app_encode_term toplevel t  =
              T.app
                ~ty:(List.nth types 1)
                const_ae_app
-               [CCOpt.get_exn (T.ty arg'); List.nth types 1; term; arg']
+               [CCOption.get_exn_or "Zipper" (T.ty arg'); List.nth types 1; term; arg']
            | T.Bind (Binder.ForallTy, var, t) ->
              assert (is_type arg);
              let arg' = app_encode_ty arg in

--- a/src/prover_calculi/avatar/Libzipperposition_avatar.ml
+++ b/src/prover_calculi/avatar/Libzipperposition_avatar.ml
@@ -113,7 +113,7 @@ module Make(E : Env.S)(Sat : Sat_solver.S)
         if E.flex_get k_abstract_known_singletons then (
           let lits = Array.of_list lits in
           let bool_name = BBox.find_boolean_lit lits in
-          CCOpt.iter (fun bool_lit -> 
+          CCOption.iter (fun bool_lit -> 
               (* asserting Trail -> bool_name *)
               if List.for_all (fun bg -> 
                   BBox.Lit.equal (BBox.Lit.neg bg) bool_lit)
@@ -167,7 +167,7 @@ module Make(E : Env.S)(Sat : Sat_solver.S)
       (not @@ E.flex_get k_split_only_initial || C.proof_depth c == 0) &&
       (not @@ E.flex_get k_split_only_ground || C.is_ground c) &&
       (not @@ E.flex_get k_split_only_goals || 
-       CCOpt.get_or ~default:(-1) (C.distance_to_goal c) >= 0) &&
+       CCOption.get_or ~default:(-1) (C.distance_to_goal c) >= 0) &&
       (not @@ E.flex_get k_abstract_known_singletons ||
        Array.length (C.lits c) != 0) &&
       (E.flex_get k_abstract_known_singletons ||

--- a/src/prover_calculi/avatar/dune
+++ b/src/prover_calculi/avatar/dune
@@ -3,5 +3,5 @@
   (public_name libzipperposition.avatar)
   (synopsis "Avatar calculus for the Zipperposition theorem prover")
   (libraries libzipperposition)
-  (flags :standard -w -32)
+  (flags :standard -w -a)
 )

--- a/src/prover_calculi/bce.ml
+++ b/src/prover_calculi/bce.ml
@@ -133,7 +133,7 @@ module Make(E : Env.S) : S with module Env = E = struct
 
     if not (ID.Set.mem sym !ignored_symbols) then (
       let sym_occs sym sign =
-        CCOpt.map_or ~default:0 C.ClauseSet.cardinal
+        CCOption.map_or ~default:0 C.ClauseSet.cardinal
           (SymSignIdx.find_opt (sym,sign) !ss_idx)
       in
 
@@ -145,7 +145,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         Util.debugf ~section 5 "ignoring symbol @[%a@]@." (fun k -> k ID.pp sym);
       ) else (
         ss_idx := SymSignIdx.update (sym, sign) (fun old ->
-          Some (C.ClauseSet.add cl (CCOpt.get_or ~default:C.ClauseSet.empty old))
+          Some (C.ClauseSet.add cl (CCOption.get_or ~default:C.ClauseSet.empty old))
         ) !ss_idx;
       )
     )
@@ -154,7 +154,7 @@ module Make(E : Env.S) : S with module Env = E = struct
      with given lhs and sign  *)
   let find_candidates hd sign = 
     C.ClauseSet.to_list
-      (CCOpt.get_or
+      (CCOption.get_or
           ~default:C.ClauseSet.empty
         (SymSignIdx.find_opt (hd, not sign) !ss_idx))
   
@@ -263,7 +263,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           SymSignIdx.update (T.head_exn lhs, L.is_positivoid lit) (function
             | Some old ->
               let new_ = C.ClauseSet.remove cl old in
-              CCOpt.return_if (not (C.ClauseSet.is_empty new_)) new_
+              CCOption.return_if (not (C.ClauseSet.is_empty new_)) new_
             | None -> None (*already removed*)) !ss_idx;
       | _ -> ()
     ) (C.lits cl)
@@ -271,7 +271,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let lock_clause locker locked_task =
     assert(C.id locker == C.id (DEQ.peek_front locked_task.cands));
     clause_lock := Util.Int_map.update (C.id locker) (fun old_val -> 
-      let locked_tasks = CCOpt.get_or ~default:[] old_val in
+      let locked_tasks = CCOption.get_or ~default:[] old_val in
       Some (locked_task :: locked_tasks)
     ) !clause_lock
 
@@ -379,7 +379,7 @@ module Make(E : Env.S) : S with module Env = E = struct
              part -- we have won as those literals will not be removed with L-resolution *)
           let is_valid_compl_lits =
             List.exists (fun lit' ->
-              CCOpt.is_some (CCArray.find_map_i (fun idx lit ->
+              CCOption.is_some (CCArray.find_map_i (fun idx lit ->
                 if idx != l_idx &&
                   are_opposite_lits_up_to ~subst (lit, sc_orig) (lit', sc_partner) then(
                   Some ())
@@ -398,9 +398,9 @@ module Make(E : Env.S) : S with module Env = E = struct
             (* else, we do L-resolution with the unifiable part extended *)
             let contrasting, rest' =
               CCList.partition (fun (lhs,_) ->
-                CCOpt.is_some (
+                CCOption.is_some (
                   List.find_opt (fun (lit, sc) ->
-                    let lhs'  = CCOpt.get_exn (L.View.get_lhs lit) in
+                    let lhs'  = CCOption.get_exn_or "Zipper" (L.View.get_lhs lit) in
                     Unif.FO.equal ~subst (lhs',sc) (lhs, sc_partner)
                   )
                   for_tautology_checking))  
@@ -497,7 +497,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     in
 
     let check_resolvents l_idx orig_cl (same_hd_atms, diff_hd_lits) =
-      let orig_args = T.args @@ CCOpt.get_exn @@ (L.View.get_lhs (C.lits orig_cl).(l_idx)) in
+      let orig_args = T.args @@ CCOption.get_exn_or "Zipper" @@ (L.View.get_lhs (C.lits orig_cl).(l_idx)) in
 
       (* add equations that correspond to computing a flat resolvent between
          original lit and the one that has new_args arguments to the head *)
@@ -523,8 +523,8 @@ module Make(E : Env.S) : S with module Env = E = struct
       let for_congruence_testing =
         CCList.filter_map (fun lit -> 
           if L.is_predicate_lit lit && L.is_positivoid lit = orig_sign then (
-            CCOpt.flat_map (fun t -> 
-              CCOpt.return_if 
+            CCOption.flat_map (fun t -> 
+              CCOption.return_if 
                 (match T.head t, T.head orig_lhs with
                  | Some hd, Some hd' -> ID.equal hd hd'
                  | _ -> false)
@@ -536,7 +536,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let orig_cc =
         List.fold_left (fun acc lit -> 
           assert (L.is_negativoid lit);
-          let lhs,rhs,_ = CCOpt.get_exn @@ L.View.as_eqn lit in
+          let lhs,rhs,_ = CCOption.get_exn_or "Zipper" @@ L.View.as_eqn lit in
           CC.mk_eq acc lhs rhs
         ) (CC.create ~size:16 ()) all_neg
       in
@@ -558,7 +558,7 @@ module Make(E : Env.S) : S with module Env = E = struct
              part -- we have won as those literals will not be removed with L-resolution *)
           let is_valid_compl_lits =
             List.exists (fun lit' ->
-              CCOpt.is_some (CCArray.find_map_i (fun idx lit ->
+              CCOption.is_some (CCArray.find_map_i (fun idx lit ->
                 if idx != l_idx &&
                   are_opposite_lits_up_to ~cc lit lit' then(
                   Some ())
@@ -617,7 +617,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let cl = task.clause in
       let lit_idx = task.lit_idx in
       let hd_sym = 
-        T.head_exn @@ CCOpt.get_exn @@ L.View.get_lhs (C.lits cl).(lit_idx)
+        T.head_exn @@ CCOption.get_exn_or "Zipper" @@ L.View.get_lhs (C.lits cl).(lit_idx)
       in
       let is_alone_with_polarity () =
         let sign = L.is_positivoid (C.lits cl).(lit_idx) in
@@ -800,7 +800,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           );
           Signal.on_every Env.ProofState.PassiveSet.on_remove_clause remove_cl_sat;
           Signal.on_every Env.on_forward_simplified (fun (_,state) ->
-            CCOpt.iter (add_cl_sat) state);
+            CCOption.iter (add_cl_sat) state);
           Signal.on_every Env.ProofState.ActiveSet.on_remove_clause remove_cl_sat;
         ) else (
           (* clauses begin their life when they are added to the passive set *)

--- a/src/prover_calculi/bool_encode.ml
+++ b/src/prover_calculi/bool_encode.ml
@@ -243,7 +243,7 @@ let bool_encode_term t_orig  =
       if T.equal (T.ty_exn t) T.tType 
       then bool_encode_ty t
       else (
-        let ty = bool_encode_ty (CCOpt.get_exn (T.ty t)) in
+        let ty = bool_encode_ty (CCOption.get_exn_or "Zipper" (T.ty t)) in
         match T.view t with
           | T.Const c -> 
             T.const ~ty c
@@ -294,7 +294,7 @@ let bool_encode_term t_orig  =
           | T.Bind (Binder.Lambda, var, body) ->
             let var' = encode_var var in
             let body' = aux body in
-            let ty = bool_encode_ty (CCOpt.get_exn (T.ty t)) in
+            let ty = bool_encode_ty (CCOption.get_exn_or "Zipper" (T.ty t)) in
             T.bind ~ty Binder.Lambda var' body'
           | T.Bind (((Forall|Exists as b)), x, body) ->
             let head = if b = Forall then forall_term else exists_term in

--- a/src/prover_calculi/booleans.ml
+++ b/src/prover_calculi/booleans.ml
@@ -272,7 +272,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         ) immediate_args in
 
     if C.proof_depth cl < Env.flex_get k_trigger_bool_ind &&
-       CCOpt.is_some (C.distance_to_goal cl) then (
+       CCOption.is_some (C.distance_to_goal cl) then (
       match C.lits cl with
       | [| Literal.Equation(lhs, rhs, _) as lit |] ->
         let res = 
@@ -373,7 +373,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                 ~rule:(Proof.Rule.mk "bool_hoist") ~tags:[Proof.Tag.T_ho] in
 
     let bool_subterms  = get_bool_hoist_eligible c in
-    CCOpt.return_if (not @@ CCList.is_empty bool_subterms) (
+    CCOption.return_if (not @@ CCList.is_empty bool_subterms) (
       CCList.fold_left (fun acc (t,_) ->
         let t,c = handle_poly_bool_hoist t c in
         let neg_lit, repl_neg = no t, T.true_ in
@@ -468,7 +468,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           let unif_seq =
             get_unif_alg () (zx, sc_zx) (u, sc_cl)
             |> OSeq.flat_map (fun us_opt -> 
-              CCOpt.map_or ~default:OSeq.empty (fun us ->
+              CCOption.map_or ~default:OSeq.empty (fun us ->
                 assert(not @@ US.has_constr us);
                 let sub = US.subst us in
                 let renaming = Subst.Renaming.create () in
@@ -557,7 +557,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let lits = Literals.apply_subst renaming sub ((C.lits c), sc_cl) in
       Literals.Pos.replace lits ~at ~by:partner.repl;
       let new_lits =
-        (CCOpt.map_or ~default:[] (fun x -> [L.apply_subst renaming sub (x,sc_partner)]) partner.new_lit)
+        (CCOption.map_or ~default:[] (fun x -> [L.apply_subst renaming sub (x,sc_partner)]) partner.new_lit)
         @ (Array.to_list (lits))
       in
       let rule = Proof.Rule.mk "fluid_log_symbol_hoist" in
@@ -586,7 +586,7 @@ module Make(E : Env.S) : S with module Env = E = struct
             let seq = 
               get_unif_alg () (p.unif_partner, sc_partner) (var, sc_cl)
               |> OSeq.filter_map (
-                CCOpt.map (fun us -> 
+                CCOption.map (fun us -> 
                   assert(not (Unif_subst.has_constr us));
                   let sub = Unif_subst.subst us in
                   let eligible' = C.eligible_res (c, sc_cl) sub in
@@ -671,7 +671,7 @@ module Make(E : Env.S) : S with module Env = E = struct
             let seq = 
               get_unif_alg () (p.unif_partner, sc_partner) (var, sc_cl)
               |> OSeq.filter_map (
-                CCOpt.map (fun us -> 
+                CCOption.map (fun us -> 
                   assert(not (Unif_subst.has_constr us));
                   let sub = Unif_subst.subst us in
                   let eligible' = C.eligible_res (c, sc_cl) sub in
@@ -714,7 +714,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let seq =
         get_unif_alg () (app_var, 0) (target, 0)
         |> OSeq.filter_map (
-            CCOpt.map (fun us -> 
+            CCOption.map (fun us -> 
               assert(not (Unif_subst.has_constr us));
               let sub = Unif_subst.subst us in
               let renaming = Subst.Renaming.create () in
@@ -823,7 +823,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           (Builtin.is_logical_binop hd || hd = Builtin.Not)
           && List.for_all T.is_var args
         | _ -> false)) 
-    |> CCOpt.map (fun (t,_) -> 
+    |> CCOption.map (fun (t,_) -> 
         let vars = T.VarSet.to_list (T.vars t) in
         assert (List.for_all (fun t -> Type.is_prop (HVar.ty t)) vars);
         all_bool_substs vars
@@ -838,7 +838,7 @@ module Make(E : Env.S) : S with module Env = E = struct
 
     let is_var_headed t = T.is_var (T.head_term t) in
     let is_eligible xs =
-      CCOpt.return_if ((List.for_all is_var_headed xs) && (List.exists T.is_app_var xs)) xs
+      CCOption.return_if ((List.for_all is_var_headed xs) && (List.exists T.is_app_var xs)) xs
     in
 
     let create_targets n =
@@ -869,7 +869,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         List.map (fun target -> 
           get_unif_alg_l () (args, 0) (target, 0)
           |> OSeq.filter_map (
-              CCOpt.map (fun us -> 
+              CCOption.map (fun us -> 
                 assert(not (Unif_subst.has_constr us));
                 let sub = Unif_subst.subst us in
                 let renaming = Subst.Renaming.create () in
@@ -968,7 +968,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         let rest = if CCArray.exists Literal.is_trivial (C.lits hoisted) then acc else hoisted :: acc in
         CCList.cons_maybe (quant_rw ~at:p b body) (rest)
       | _ -> acc) []
-    |> (fun res -> CCOpt.return_if (not @@ CCList.is_empty res) res)
+    |> (fun res -> CCOption.return_if (not @@ CCList.is_empty res) res)
 
    let nested_eq_rw c =
     (* TODO(BOOL): currently incompatible with combiantors *)
@@ -982,7 +982,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         Some (
           get_unif_alg () (mk_sc a) (mk_sc b)
           |> OSeq.map (fun unif_subst_opt ->
-              CCOpt.map (fun unif_subst -> 
+              CCOption.map (fun unif_subst -> 
                 assert (not @@ US.has_constr unif_subst);
                 let subst = US.subst unif_subst in
                 let repl = 
@@ -1021,7 +1021,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       if L.is_predicate_lit lit then (
         match lit with
         | L.Equation(lhs,_,_) ->
-          CCOpt.get_exn (FR.rename_form ~polarity_aware:false ~c lhs sign)
+          CCOption.get_exn_or "Zipper" (FR.rename_form ~polarity_aware:false ~c lhs sign)
         | _ -> assert false
       ) else (
         let mk_form =
@@ -1029,7 +1029,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         in
         match lit with
         | L.Equation(lhs,rhs,_) ->
-          CCOpt.get_exn (FR.rename_form ~polarity_aware:false ~c (mk_form lhs rhs) sign)
+          CCOption.get_exn_or "Zipper" (FR.rename_form ~polarity_aware:false ~c (mk_form lhs rhs) sign)
         | _ -> assert false
       )
     in
@@ -1082,7 +1082,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       let open Term in
       let compl_in_l l =
         let pos, neg = 
-          CCList.partition_map (fun t ->
+          CCList.partition_filter_map (fun t ->
               match view t with
               | AppBuiltin(Builtin.Not, [s]) -> `Right s
               | _ -> `Left t) l
@@ -1507,7 +1507,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           Util.debugf ~section 5 "unif problem: @[%a=?=%a@]@."(fun k -> k T.pp l T.pp r);
           let stm = 
             unif_alg l r
-            |> OSeq.map (CCOpt.map (fun subst -> 
+            |> OSeq.map (CCOption.map (fun subst -> 
               let renaming = Subst.Renaming.create () in
               let new_lits =
                 CCArray.except_idx (C.lits c) i
@@ -1575,7 +1575,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           )) cnf_vec;
       let solved = 
         if Env.flex_get k_solve_formulas then (
-          CCOpt.get_or ~default:[] (solve_bool_formulas ~which:`All c))
+          CCOption.get_or ~default:[] (solve_bool_formulas ~which:`All c))
         else [] in
 
       let clauses = CCVector.map (C.of_statement ~convert_defs:true) cnf_vec
@@ -1591,7 +1591,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     | None -> None
 
   let cnf_infer cl = 
-    CCOpt.get_or ~default:[] (cnf_otf cl)
+    CCOption.get_or ~default:[] (cnf_otf cl)
 
   let interpret_boolean_functions c =
     (* Collects boolean functions only at top level, 
@@ -1691,7 +1691,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       if Env.flex_get k_solve_formulas then (
         Env.add_unary_inf "solve formulas" (
           fun c -> 
-            CCOpt.get_or ~default:[] @@
+            CCOption.get_or ~default:[] @@
             solve_bool_formulas ~which:`OnlyPositive c
         ));
       if Env.flex_get k_trigger_bool_inst > 0 || Env.flex_get k_trigger_bool_ind > 0 then (
@@ -1774,7 +1774,7 @@ let map_propositions ~proof f =
     )
 
 
-let is_bool t = CCOpt.equal Ty.equal (Some prop) (ty t)
+let is_bool t = CCOption.equal Ty.equal (Some prop) (ty t)
 let is_T_F t = match view t with AppBuiltin((True|False),[]) -> true | _ -> false
 
 (* Modify every subterm of t by f except those at the "top". Here top is true if subterm occurs under a quantifier Æ in a context where it could participate to the clausification if the surrounding context of Æ was ignored. *)
@@ -1939,7 +1939,7 @@ let eager_cases_near stms =
           when not top && no_leaky_variables p ->
         return p
       | Bind(Binder.Lambda, var, body) ->
-        CCOpt.map (fun (body_t, body_f, s) -> 
+        CCOption.map (fun (body_t, body_f, s) -> 
           assert(no_leaky_variables s);
           (T.fun_l [var] body_t, T.fun_l [var] body_f, s)
         ) (aux ~top:false body)
@@ -1948,11 +1948,11 @@ let eager_cases_near stms =
       | Const _ when not top && T.Ty.is_prop p_ty  ->
         return p
       | AppBuiltin(b, args) ->
-        CCOpt.map (fun (args_t,args_f, s) -> 
+        CCOption.map (fun (args_t,args_f, s) -> 
           (T.app_builtin ~ty:p_ty b args_t, T.app_builtin ~ty:p_ty b args_f, s)
         ) (aux_l args)
       | App(hd,args) ->
-        CCOpt.map (fun (args_t,args_f, s) -> 
+        CCOption.map (fun (args_t,args_f, s) -> 
           (T.app ~ty:p_ty hd args_t, T.app ~ty:p_ty hd args_f, s)
         ) (aux_l args)
       | _ -> None

--- a/src/prover_calculi/dune
+++ b/src/prover_calculi/dune
@@ -3,5 +3,5 @@
   (public_name libzipperposition.calculi)
   (synopsis "calculi for the Zipperposition theorem prover")
   (libraries libzipperposition libzipperposition.avatar)
-  (flags :standard -w -32)
+  (flags :standard -w -a)
 )

--- a/src/prover_calculi/enumTypes.ml
+++ b/src/prover_calculi/enumTypes.ml
@@ -435,7 +435,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     let aux i =
       try
         let decl = find_decl_ i in
-        check_decl_ ~ty s decl |> CCOpt.to_list
+        check_decl_ ~ty s decl |> CCOption.to_list
       with Not_found -> []
     in
     let clauses =
@@ -468,7 +468,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     match detect_declaration c with
     | None -> ()
     | Some (var,cases) ->
-      let ty_id = CCOpt.get_exn (as_simple_ty (HVar.ty var)) in
+      let ty_id = CCOption.get_exn_or "Zipper" (as_simple_ty (HVar.ty var)) in
       let is_new = declare_ ~ty_id ~ty_vars:[] ~var ~proof:(`Clause (C.proof c)) cases in
       (* clause becomes redundant if it's a new declaration *)
       match is_new with

--- a/src/prover_calculi/fool.ml
+++ b/src/prover_calculi/fool.ml
@@ -173,12 +173,12 @@ module Make(E : Env.S) : S with module Env = E = struct
                let lits = CCArray.except_idx (C.lits c) i in
                l
                |> List.map (fun t -> Literal.mk_prop t sign :: lits |> mk_c)
-               |> CCOpt.return
+               |> CCOption.return
              | T.AppBuiltin (Builtin.Or, l), true
              | T.AppBuiltin (Builtin.And, l), false ->
                let lits = CCArray.except_idx (C.lits c) i in
                (List.map (fun t -> Literal.mk_prop t sign) l @ lits)
-               |> mk_c |> CCList.return |> CCOpt.return
+               |> mk_c |> CCList.return |> CCOption.return
              | T.AppBuiltin (Builtin.Eq, [_;t;u]), _ ->
                let lits = CCArray.except_idx (C.lits c) i in
                let lit = Literal.mk_lit t u sign in

--- a/src/prover_calculi/heuristics.ml
+++ b/src/prover_calculi/heuristics.ml
@@ -43,7 +43,7 @@ module Make(E : Env.S) = struct
     |> Iter.map T.ty
     |> Iter.map (fun t -> InnerTerm.depth (t : Type.t :> InnerTerm.t))
     |> Iter.max ?lt:None
-    |> CCOpt.map_or ~default:0 CCFun.id
+    |> CCOption.map_or ~default:0 CCFun.id
 
   let is_too_deep c =
     match !depth_limit_ with

--- a/src/prover_calculi/hlb_elim.ml
+++ b/src/prover_calculi/hlb_elim.ml
@@ -115,7 +115,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         | x :: xs' ->
           begin match ys with
           | y :: ys' ->
-            if (not (T.equal x y)) && CCOpt.is_none acc then (
+            if (not (T.equal x y)) && CCOption.is_none acc then (
               aux (Some (x,y)) xs' ys'
             ) else if T.equal x y then aux acc xs' ys'
             else None
@@ -214,7 +214,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     Trail.is_empty (C.trail cl) &&
     (match C.lits cl with
     | [| l1; l2 |] -> 
-      CCOpt.is_some (get_predicate l1) && CCOpt.is_some (get_predicate l2)
+      CCOption.is_some (get_predicate l1) && CCOption.is_some (get_predicate l2)
     | _ -> false)
 
   let [@inline] rec normalize_negations lhs =
@@ -321,8 +321,8 @@ module Make(E : Env.S) : S with module Env = E = struct
     let neg_concl = normalize_negations (T.Form.not_ concl) in
     let neg_concl_flip = normalize_negations (T.Form.not_ (flip_eq concl)) in
     T.Tbl.find_opt tbl neg_concl
-    |> CCOpt.(<+>) (T.Tbl.find_opt tbl neg_concl_flip)
-    |> CCOpt.(<$>) (CS.add cl)
+    |> CCOption.(<+>) (T.Tbl.find_opt tbl neg_concl_flip)
+    |> CCOption.(<$>) (CS.add cl)
 
   (* find already stored implications a -> b such that premise\sigma = b.
      Then, store the implication a -> concl\sigma   *)
@@ -445,7 +445,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         );
         (* if by adding concl something became unit we remove
            the leaf as the new one with updated unit status will be added *)
-        CCOpt.is_none !became_unit
+        CCOption.is_none !became_unit
       );
 
       (match !became_unit with 
@@ -579,12 +579,12 @@ module Make(E : Env.S) : S with module Env = E = struct
             retrieve_idx ~getter:(PropagatedLitsIdx.retrieve_generalizations (!propagated_, idx_sc)) 
               (i_t, q_sc)
             |> Iter.head
-            |> CCOpt.iter (fun (_,ps,_) -> raise (UnitHTR(i,ps))));
+            |> CCOption.iter (fun (_,ps,_) -> raise (UnitHTR(i,ps))));
 
           if Env.flex_get k_delete_lits then (
             retrieve_idx ~getter:(PropagatedLitsIdx.retrieve_generalizations (!propagated_, idx_sc)) (i_neg_t, q_sc)
             |> Iter.head
-            |> CCOpt.iter (fun (_,(ps, _),_) -> 
+            |> CCOption.iter (fun (_,(ps, _),_) -> 
               proofset := CS.union ps !proofset;
               CCBV.reset bv i))
         | None -> ()
@@ -630,7 +630,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       if Env.flex_get k_heartbeat_disabled_hlbe then raise RuleNotApplicable;
       if n > 7 then raise RuleNotApplicable; 
       let bv = CCBV.create ~size:n true in
-      let (<+>) = CCOpt.(<+>) in
+      let (<+>) = CCOption.(<+>) in
       let proofset = ref CS.empty in
       CCArray.iteri (fun i i_lit ->
         match get_predicate i_lit with
@@ -747,7 +747,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     | None -> SimplM.return_same cl)
 
   let [@inline] check_heartbeat arg =
-    if CCOpt.is_some arg then heartbeat_ := true;
+    if CCOption.is_some arg then heartbeat_ := true;
     arg 
 
   let hle_htr = simplify_opt ~f:(fun a -> check_heartbeat @@ do_hte_hle a)

--- a/src/prover_calculi/ind_types.ml
+++ b/src/prover_calculi/ind_types.ml
@@ -36,7 +36,7 @@ module Make(Env : Env_intf.S) = struct
       | T.AppBuiltin _ -> None
     end
 
-  let is_cstor_app t = CCOpt.is_some (as_cstor_app t)
+  let is_cstor_app t = CCOption.is_some (as_cstor_app t)
 
   (* traverse all the sub-terms under at least one constructor *)
   let walk_cstor_args (t:term): term Iter.t =
@@ -256,7 +256,7 @@ module Make(Env : Env_intf.S) = struct
            This way, the case will be smaller than the constant. *)
         let depth = match T.view t with
           | T.Const id ->
-            Ind_cst.id_as_cst id |> CCOpt.map Ind_cst.depth |> CCOpt.map succ
+            Ind_cst.id_as_cst id |> CCOption.map Ind_cst.depth |> CCOption.map succ
           | _ -> None
         in
         Ind_cst.make ~is_sub:false ?depth ty |> Ind_cst.id

--- a/src/prover_calculi/induction/Libzipperposition_induction.ml
+++ b/src/prover_calculi/induction/Libzipperposition_induction.ml
@@ -809,7 +809,7 @@ module Make
               Cut_form.vars f
               |> T.VarSet.to_iter
               |> Iter.map HVar.id
-              |> Iter.max |> CCOpt.get_or ~default:0 |> succ
+              |> Iter.max |> CCOption.get_or ~default:0 |> succ
             in
             CCList.foldi
               (fun m i v ->
@@ -874,7 +874,7 @@ module Make
                Cut_form.vars f
                |> T.VarSet.to_iter
                |> Iter.map HVar.id
-               |> Iter.max |> CCOpt.get_or ~default:0 |> succ
+               |> Iter.max |> CCOption.get_or ~default:0 |> succ
                |> HVar.make ~ty:(T.ty t)
              in
              let m =
@@ -1148,7 +1148,7 @@ module Make
       Iter.of_list generalize_on
       |> Iter.map (fun (id,_) -> Ind_cst.ind_skolem_depth id)
       |> Iter.max
-      |> CCOpt.get_or ~default:0
+      |> CCOption.get_or ~default:0
     (* the trail should not contain a positive "lemma" atom.
        We accept negative lemma atoms because the induction can be used to
        prove the lemma *)
@@ -1273,7 +1273,7 @@ module Make
       |> Iter.filter_map
         (fun lit ->
            BoolBox.as_lemma lit
-           |> CCOpt.map (fun lemma -> lemma, BoolLit.sign lit))
+           |> CCOption.map (fun lemma -> lemma, BoolLit.sign lit))
     in
     (* are there two distinct positive lemma literals in the trail? *)
     Iter.diagonal relevant_cases

--- a/src/prover_calculi/induction/dune
+++ b/src/prover_calculi/induction/dune
@@ -4,4 +4,4 @@
   (public_name libzipperposition.induction)
   (synopsis "Induction calculus for the Zipperposition theorem prover")
   (libraries libzipperposition libzipperposition.avatar logtk.arith)
-  (flags :standard -w -32 -open Logtk_arith))
+  (flags :standard -w -a -open Logtk_arith))

--- a/src/prover_calculi/lazy_cnf.ml
+++ b/src/prover_calculi/lazy_cnf.ml
@@ -98,7 +98,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   (* if k_clausify_eq_max_nonint is disabled, then we will not clausify
      if the max side is non-interpreted *)
   let check_eq_cnf_ordering_conditions lhs rhs =
-    let is_noninterpeted t = CCOpt.is_some (Term.head t) in
+    let is_noninterpeted t = CCOption.is_some (Term.head t) in
     let ord = E.Ctx.ord () in
     (E.flex_get k_clausify_eq_max_nonint) ||
     (match Ordering.compare ord lhs rhs with
@@ -254,13 +254,13 @@ module Make(E : Env.S) : S with module Env = E = struct
     if Env.flex_get k_rename_eq 
     then (
       if (yields_clauses lhs && yields_clauses rhs) then
-        (CCOpt.map (fun (r,d,p) -> app_sign r, d, p)
+        (CCOption.map (fun (r,d,p) -> app_sign r, d, p)
           (FR.rename_form ~should_rename ~polarity_aware ~c (T.Form.equiv lhs rhs) sign))
       else if yields_clauses lhs then
-        (CCOpt.map (fun (r,d,p) -> app_sign (T.Form.eq r rhs), d, p) 
+        (CCOption.map (fun (r,d,p) -> app_sign (T.Form.eq r rhs), d, p) 
           (FR.rename_form ~should_rename ~polarity_aware:false ~c lhs sign))
       else if yields_clauses rhs then
-        (CCOpt.map (fun (r,d,p) -> app_sign (T.Form.eq lhs r), d, p) 
+        (CCOption.map (fun (r,d,p) -> app_sign (T.Form.eq lhs r), d, p) 
           (FR.rename_form ~should_rename ~polarity_aware:false ~c rhs sign))
       else None
     ) else None
@@ -281,7 +281,7 @@ module Make(E : Env.S) : S with module Env = E = struct
 
   let cnf_scope_form form =
     let kind = Env.flex_get k_scoping in
-    let open CCOpt in
+    let open CCOption in
 
     let rec maxiscoping_eligible l =
       let get_quant t = 
@@ -360,7 +360,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       ) else (
         FR.get_skolem ~parent ~mode:(Env.flex_get k_skolem_mode) f
         |> CCFun.tap (fun t ->
-          CCOpt.iter (fun hd_id -> 
+          CCOption.iter (fun hd_id -> 
           ID.set_payload (hd_id) (ID.Attr_skolem ID.K_lazy_cnf)) (T.head t))) 
     in
     let expand_quant = not @@ Env.flex_get Combinators.k_enable_combinators in
@@ -500,7 +500,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                       ~tags:[Proof.Tag.T_live_cnf;
                              Proof.Tag.T_dont_increase_depth] in
     clausify_quants ~proof_cons c
-    |> CCOpt.map_or ~default:(SimplM.return_same c) (SimplM.return_new)
+    |> CCOption.map_or ~default:(SimplM.return_same c) (SimplM.return_new)
 
 
   let rename_subformulas c =
@@ -601,7 +601,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       Proof.Step.inference ~infos:[] 
                       ~tags:[Proof.Tag.T_live_cnf;
                              Proof.Tag.T_dont_increase_depth] in
-    CCOpt.map_or ~default:[] (fun c -> [c]) @@ clausify_quants ~proof_cons c
+    CCOption.map_or ~default:[] (fun c -> [c]) @@ clausify_quants ~proof_cons c
 
   let clausify_eq c =
     let rule_name = "eq_elim" in

--- a/src/prover_calculi/pred_elim.ml
+++ b/src/prover_calculi/pred_elim.ml
@@ -118,7 +118,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     CCFormat.fprintf out 
       "%a(%b) {@. +: @[%a@];@. -:@[%a@];@. ?:@[%a@]@. g:@[%a@]@. v^2:@[%g@]; |l|:@[%d@]; |%a|:@[%d@]; h_idx: @[%d@] @.}@."
       ID.pp task.sym original (CS.pp C.pp) task.pos_cls (CS.pp C.pp) task.neg_cls
-      (CS.pp C.pp) task.offending_cls (CCOpt.pp (CCPair.pp (CCList.pp C.pp) (CCList.pp C.pp))) task.maybe_gate task.sq_var_weight
+      (CS.pp C.pp) task.offending_cls (CCOption.pp (CCPair.pp (CCList.pp C.pp) (CCList.pp C.pp))) task.maybe_gate task.sq_var_weight
       task.num_lits ID.pp task.sym (estimated_gain task) task.heap_idx
 
   let copy_task t = 
@@ -144,7 +144,7 @@ module Make(E : Env.S) : S with module Env = E = struct
       if not a.deleted && not b.deleted then (
           let open CCOrd in
           (compare (estimated_gain a) (estimated_gain b)
-          <?> (compare, not (CCOpt.is_some a.maybe_gate), not (CCOpt.is_some b.maybe_gate))
+          <?> (compare, not (CCOption.is_some a.maybe_gate), not (CCOption.is_some b.maybe_gate))
           <?> (compare, a.num_lits, b.num_lits)
           <?> (compare, a.sq_var_weight, b.sq_var_weight)
           <?> (ID.compare, a.sym, b.sym)) < 0
@@ -215,7 +215,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         None
       else if Type.is_prop (T.ty lhs) then (
         if L.is_predicate_lit lit then (
-          CCOpt.map (fun hd_sym -> (hd_sym, sign)) (T.head lhs)
+          CCOption.map (fun hd_sym -> (hd_sym, sign)) (T.head lhs)
         ) else (
           None;
       )) else (_logic := Equational; None)
@@ -349,7 +349,7 @@ module Make(E : Env.S) : S with module Env = E = struct
     let update_idx pos neg offending gates num_vars cl =
       let update ~action sym =
         _pred_sym_idx := ID.Map.update sym (fun old ->
-          let entry = CCOpt.get_or ~default:(mk_pred_elim_info sym) old in
+          let entry = CCOption.get_or ~default:(mk_pred_elim_info sym) old in
           let old_ = copy_task entry in
           begin match action with
           | `Pos ->
@@ -504,7 +504,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                 if TaskSet.in_heap old && TaskSet.in_heap task then (
                   TaskSet.update _task_queue ~new_:task ~old;
                 );
-              CCOpt.return_if (not (ID.Set.mem task.sym !_ignored_symbols)) task
+              CCOption.return_if (not (ID.Set.mem task.sym !_ignored_symbols)) task
             | None -> None) !_pred_sym_idx
         ) (C.symbols (Iter.singleton cl)));
       Signal.ContinueListening)
@@ -513,7 +513,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let replace_clauses task clauses =
     Util.debugf ~section 2 "replaced clauses(%a):@. regular:@[%a@]@. gates:@[%a@]@." 
       (fun k -> k ID.pp task.sym (CS.pp C.pp) (CS.union task.pos_cls task.neg_cls) 
-                  (CCOpt.pp (CCPair.pp (CCList.pp C.pp) (CCList.pp C.pp))) task.maybe_gate);
+                  (CCOption.pp (CCPair.pp (CCList.pp C.pp) (CCList.pp C.pp))) task.maybe_gate);
     Util.debugf ~section 2 "resolvents: @[%a@]@." (fun k -> k (CCList.pp C.pp) clauses);
     _ignored_symbols := ID.Set.add task.sym !_ignored_symbols;
     let remove iter =
@@ -545,10 +545,10 @@ module Make(E : Env.S) : S with module Env = E = struct
     Literals.is_trivial (C.lits c) || Trail.is_trivial (C.trail c)
 
   let find_lit_by_sym sym sign cl =
-    CCOpt.get_exn (CCArray.find_map_i (fun idx lit -> 
+    CCOption.get_exn_or "Zipper" (CCArray.find_map_i (fun idx lit -> 
       match get_sym_sign lit with
       | Some (sym', sign') when ID.equal sym sym' && sign = sign' -> 
-        Some (idx, CCOpt.get_exn (L.View.get_lhs lit))
+        Some (idx, CCOption.get_exn_or "Zipper" (L.View.get_lhs lit))
       | _ -> None
     ) (C.lits cl))
 
@@ -578,7 +578,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         C.create ~penalty:(max (C.penalty pos_cl) (C.penalty neg_cl))
                  ~trail:(C.trail_l [pos_cl; neg_cl]) lits proof
       in
-      CCOpt.return_if (not (is_tauto c)) c
+      CCOption.return_if (not (is_tauto c)) c
     with Unif.Fail -> None
   
   let eq_resolver ~sym ~pos_cl ~neg_cl =
@@ -638,7 +638,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           C.create ~penalty:(max (C.penalty pos_cl') (C.penalty neg_cl'))
                     ~trail:(C.trail_l [pos_cl'; neg_cl']) lits (proof subst renaming)
       in
-      CCOpt.return_if (not (is_tauto c)) c
+      CCOption.return_if (not (is_tauto c)) c
     with Unif.Fail -> None
 
   let check_if_gate task =
@@ -651,11 +651,11 @@ module Make(E : Env.S) : S with module Env = E = struct
         (match (CCArray.find_idx (fun lit -> 
           match get_sym_sign lit with 
           | Some(sym', sign') -> ID.equal sym sym' && 
-                                 ((CCOpt.is_none sign) || CCOpt.get_exn sign == sign')
+                                 ((CCOption.is_none sign) || CCOption.get_exn_or "Zipper" sign == sign')
           | None -> false) (C.lits cl)) with
         | Some (i, lit) ->
           let free_vars = T.VarSet.of_list (L.vars lit) in
-          CCOpt.is_none (CCArray.find_map_i (fun j lit'  ->
+          CCOption.is_none (CCArray.find_map_i (fun j lit'  ->
             if (i=j || T.VarSet.subset (T.VarSet.of_list (L.vars lit')) free_vars) then None
             else Some j
           ) (C.lits cl))
@@ -690,7 +690,7 @@ module Make(E : Env.S) : S with module Env = E = struct
                   | Some(sym',_) -> ID.equal sym sym'
                   | None -> false
                 ) (C.lits cl) in
-                let idx_name, _ = CCOpt.get_exn idx_name_opt in
+                let idx_name, _ = CCOption.get_exn_or "Zipper" idx_name_opt in
                 let name_lit = L.negate (C.lits cl).(idx_name) in
                 let other_lit = L.negate (C.lits cl).(1 - idx_name) in
                 let is_matched = 
@@ -773,7 +773,7 @@ module Make(E : Env.S) : S with module Env = E = struct
         in
         if List.exists (fun pos_cl -> 
           List.exists (fun neg_cl -> 
-            CCOpt.is_some @@ 
+            CCOption.is_some @@ 
               neq_resolver ~sym:task.sym ~pos_cl ~neg_cl) neg_cls
         ) pos_cls then None
         else Some (pos_cls, neg_cls)
@@ -792,7 +792,7 @@ module Make(E : Env.S) : S with module Env = E = struct
           let parents = List.map (fun p -> Proof.S.step @@ Proof.Parent.proof p) (Proof.Step.parents proof) in
           Util.debugf ~section 5 "SAT prover found unsat set: %d@." (fun k -> k  (CCList.length parents));
           let used_cls = CCList.filter_map (fun (_,_,cl) -> 
-            CCOpt.return_if (CCList.mem ~eq:Proof.Step.equal (C.proof_step cl) parents) cl) cls  in
+            CCOption.return_if (CCList.mem ~eq:Proof.Step.equal (C.proof_step cl) parents) cl) cls  in
           Util.debugf ~section 5 "used clauses: @[%a@]@." (fun k -> k (CCList.pp C.pp) used_cls);
           split_clauses used_cls
         | _ -> None)
@@ -800,13 +800,13 @@ module Make(E : Env.S) : S with module Env = E = struct
       in
       let is_def = function
         | (Literal.Equation(lhs,_,_) as lit) when Literal.is_predicate_lit lit ->
-          CCOpt.is_some (Term.head lhs) && List.for_all T.is_var (T.args lhs)
+          CCOption.is_some (Term.head lhs) && List.for_all T.is_var (T.args lhs)
         | _ -> false
       in
       match gates_l with 
       | x :: xs ->
         (* we will standardize all clauses by the first name literal in x *)
-        let i,name_lit = CCOpt.get_exn (CCArray.find_map_i (fun i lit -> 
+        let i,name_lit = CCOption.get_exn_or "Zipper" (CCArray.find_map_i (fun i lit -> 
             match lit with 
             | L.Equation(lhs,rhs,_) when L.is_predicate_lit lit -> 
               begin match T.head lhs with
@@ -872,7 +872,7 @@ module Make(E : Env.S) : S with module Env = E = struct
   let calc_non_singular_resolvents ~sym ~pos ~neg ~offending =
     let find_lit_by_sym_opt sign cl =
       try
-        CCOpt.return (find_lit_by_sym sym sign cl)
+        CCOption.return (find_lit_by_sym sym sign cl)
       with _ -> None
     in
 
@@ -968,8 +968,8 @@ module Make(E : Env.S) : S with module Env = E = struct
               [replace_sym pos neg (ty_vars, lam) cl]))
         in
         let has_lit cl =
-          let (<+>) = CCOpt.(<+>) in
-          CCOpt.is_some (find_lit_by_sym_opt true cl <+>
+          let (<+>) = CCOption.(<+>) in
+          CCOption.is_some (find_lit_by_sym_opt true cl <+>
                          find_lit_by_sym_opt false cl)
         in
         let has_pred', no_pred' = List.partition has_lit new_cls in
@@ -1156,17 +1156,17 @@ module Make(E : Env.S) : S with module Env = E = struct
     );
 
     let ans = (do_pred_elim ()) in
-    Util.debugf ~section 1 "%% PE start fixpoint: @[%a@]@." (fun k -> k (CCOpt.pp CCInt.pp) ans);
-    Util.debugf ~section 2 "Clause number changed for %a" (fun k -> k (CCOpt.pp CCInt.pp) ans)
+    Util.debugf ~section 1 "%% PE start fixpoint: @[%a@]@." (fun k -> k (CCOption.pp CCInt.pp) ans);
+    Util.debugf ~section 2 "Clause number changed for %a" (fun k -> k (CCOption.pp CCInt.pp) ans)
 
   let fixpoint_step () =
     Util.debugf ~section 1 "relax val: %d@." (fun k -> k (Env.flex_get k_relax_val));
     let ans = do_pred_elim () in
-    Util.debugf ~section 1 "Clause number changed for %a" (fun k -> k (CCOpt.pp CCInt.pp) ans);
-    if CCOpt.is_some ans then (
-      Util.debugf ~section 1 "%% PE fixpoint: %d@." (fun k -> k (CCOpt.get_exn ans))
+    Util.debugf ~section 1 "Clause number changed for %a" (fun k -> k (CCOption.pp CCInt.pp) ans);
+    if CCOption.is_some ans then (
+      Util.debugf ~section 1 "%% PE fixpoint: %d@." (fun k -> k (CCOption.get_exn_or "Zipper" ans))
     );
-    CCOpt.is_some ans
+    CCOption.is_some ans
   
   let end_fixpoint () =
     _done := true;

--- a/src/prover_calculi/pure_literal_elim.ml
+++ b/src/prover_calculi/pure_literal_elim.ml
@@ -156,7 +156,7 @@ let get_pure_symbols forbidden ids2clauses clauses =
   (* joins all clauses in one map with occurences of symbol *)
   let all_clauses = 
     List.fold_left (fun acc cl -> 
-      IDMap.union (fun _ a b -> CCOpt.return @@ a + b) acc cl
+      IDMap.union (fun _ a b -> CCOption.return @@ a + b) acc cl
     ) IDMap.empty clauses
   in
   let all_symbols = 
@@ -187,11 +187,11 @@ let remove_pure_clauses (seq : (TST.t SLiteral.t list, TST.t, TST.t) Statement.t
   let filter_if_has_pure stmt lits =
     Util.incr_stat total_clauses;
     let ans = 
-      CCOpt.return_if 
+      CCOption.return_if 
         (ID.Set.is_empty @@ ID.Set.inter pure_syms (cl_syms lits)) 
       stmt
     in
-    if CCOpt.is_none ans then (
+    if CCOption.is_none ans then (
       Util.incr_stat removed_clauses;
       Util.debugf ~section 2 "removed: @[%a@]@." 
         (fun k -> k (CCList.pp (SLiteral.pp TST.pp)) lits); 

--- a/src/prover_calculi/superposition.ml
+++ b/src/prover_calculi/superposition.ml
@@ -480,7 +480,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
             (fun unique_args (t,_) ->
                if Term.equal (fst (T.as_app t)) var
                then (
-                 if CCOpt.equal (CCList.equal T.equal) unique_args (Some (snd (T.as_app t)))
+                 if CCOption.equal (CCList.equal T.equal) unique_args (Some (snd (T.as_app t)))
                  then (unique_args, `Continue) (* found the same arguments of var again *)
                  else (None, `Stop) (* different arguments of var found *)
                ) else (unique_args, `Continue) (* this term doesn't have var as head *)
@@ -994,8 +994,9 @@ module Make(Env : Env.S) : S with module Env = Env = struct
     let open SupInfo in
     assert (info.sup_kind=DupSup || info.sup_kind=SubVarSup || Type.equal (T.ty info.s) (T.ty info.t));
     assert (info.sup_kind=DupSup || info.sup_kind=SubVarSup ||
-            Unif.Ty.equal ~subst:(US.subst info.subst)
-              (T.ty info.s, info.scope_active) (T.ty info.u_p, info.scope_passive));
+            Type.equal
+              (Subst.Ty.apply Subst.Renaming.none (US.subst info.subst) (T.ty info.s, info.scope_active))
+              (Subst.Ty.apply Subst.Renaming.none (US.subst info.subst) (T.ty info.u_p, info.scope_passive)));
     let renaming = Subst.Renaming.create () in
     let shift_vars = if info.sup_kind = LambdaSup then 0 else -1 in
     let s = Subst.FO.apply ~shift_vars renaming (US.subst info.subst) (info.s, info.scope_active) in
@@ -1200,7 +1201,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
             (* /!\ may differ from the actual penalty (by -2) *)
             let parents = [clause; with_pos.clause] in
             let p = max (C.penalty clause) (C.penalty with_pos.clause) in
-            Some (p, parents, OSeq.map (CCOpt.flat_map (do_sup u_p with_pos)) substs))
+            Some (p, parents, OSeq.map (CCOption.flat_map (do_sup u_p with_pos)) substs))
         clause
     in
 
@@ -1220,7 +1221,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
             (* /!\ may differ from the actual penalty (by -2) *)
             let parents = [clause; with_pos.clause] in
             let p = max (C.penalty clause) (C.penalty with_pos.clause) in
-            Some (p, parents, OSeq.map (CCOpt.flat_map (do_sup u_p with_pos)) substs))
+            Some (p, parents, OSeq.map (CCOption.flat_map (do_sup u_p with_pos)) substs))
         clause
     in
     
@@ -1261,7 +1262,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
                   let ht = T.app var_h [t] in
                   let res = Env.flex_get k_unif_alg (u_p,1) (hs,0) |> OSeq.map (
                       fun osubst ->
-                        osubst |> CCOpt.flat_map (
+                        osubst |> CCOption.flat_map (
                           fun subst ->
                             let passive = with_pos.C.WithPos.clause in
                             let passive_pos = with_pos.C.WithPos.pos in
@@ -1320,7 +1321,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
                       Env.flex_get k_unif_alg (hs,1) (u_p,0)
                       |> OSeq.map
                         (fun osubst ->
-                           osubst |> CCOpt.flat_map (fun subst ->
+                           osubst |> CCOption.flat_map (fun subst ->
                                let info = SupInfo.({
                                    s = hs; t = ht; active; active_pos=s_pos; scope_active=1; subst;
                                    u_p; passive=clause; passive_lit; passive_pos; scope_passive=0; sup_kind=FluidSup
@@ -1390,7 +1391,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
                   let z_args = T.app term_z (args_up @ [t]) in
                   let res = Env.flex_get k_unif_alg (s,scope_active) (w_args,scope_passive) |> OSeq.map (
                       fun osubst ->
-                        osubst |> CCOpt.flat_map (
+                        osubst |> CCOption.flat_map (
                           fun subst ->
                             let subst = US.merge subst subst_y in
                             let passive = with_pos.C.WithPos.clause in
@@ -1469,7 +1470,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
                       let z_args = T.app term_z (List.append args_up [t]) in
                       let res = Env.flex_get k_unif_alg (w_args,scope_passive) (s,scope_active) |> OSeq.map (
                           fun osubst ->
-                            osubst |> CCOpt.flat_map (
+                            osubst |> CCOption.flat_map (
                               fun subst ->
                                 let subst = US.merge subst subst_y in
                                 let info = SupInfo.({
@@ -1646,12 +1647,12 @@ module Make(Env : Env.S) : S with module Env = Env = struct
       ~unify:(fun l r -> 
         try Some (Unif.FO.unify_full l r) 
         with Unif.Fail -> None)
-      ~iterate_substs:(fun substs do_eq_res -> CCOpt.flat_map do_eq_res substs) c
+      ~iterate_substs:(fun substs do_eq_res -> CCOption.flat_map do_eq_res substs) c
 
   let infer_equality_resolution_complete_ho clause =
     let inf_res = infer_equality_resolution_aux
         ~unify:(Env.flex_get k_unif_alg)
-        ~iterate_substs:(fun substs do_eq_res -> Some (OSeq.map (CCOpt.flat_map do_eq_res) substs))
+        ~iterate_substs:(fun substs do_eq_res -> Some (OSeq.map (CCOption.flat_map do_eq_res) substs))
         clause
     in
     if Env.should_force_stream_eval () then (
@@ -1779,12 +1780,12 @@ module Make(Env : Env.S) : S with module Env = Env = struct
         try Some (Unif.FO.unify_full s t) 
         with Unif.Fail -> 
       None)
-      ~iterate_substs:(fun subst do_eq_fact -> CCOpt.flat_map do_eq_fact subst) c
+      ~iterate_substs:(fun subst do_eq_fact -> CCOption.flat_map do_eq_fact subst) c
 
   let infer_equality_factoring_complete_ho clause =
     let inf_res = infer_equality_factoring_aux
         ~unify:(Env.flex_get k_unif_alg)
-        ~iterate_substs:(fun substs do_eq_fact -> Some (OSeq.map (CCOpt.flat_map do_eq_fact) substs))
+        ~iterate_substs:(fun substs do_eq_fact -> Some (OSeq.map (CCOption.flat_map do_eq_fact) substs))
         clause
     in
     if Env.should_force_stream_eval () then (
@@ -1807,7 +1808,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
       else
         StmQ.take_stm_nb (Env.get_stm_queue ())
     in
-    let opt_res = CCOpt.sequence_l (List.filter CCOpt.is_some cl)  in
+    let opt_res = CCOption.sequence_l (List.filter CCOption.is_some cl)  in
     ZProf.exit_prof _span;
     match opt_res with
     | None -> []
@@ -1821,7 +1822,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
       else
         StmQ.take_stm_nb_fix_stm (Env.get_stm_queue ())
     in
-    let opt_res = CCOpt.sequence_l (List.filter CCOpt.is_some cl) in
+    let opt_res = CCOption.sequence_l (List.filter CCOption.is_some cl) in
     ZProf.exit_prof _span;
     match opt_res with
     | None -> []
@@ -2357,7 +2358,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
 
     let do_sr t =
       let simplify ~sign lhs rhs =
-        let (<+>) = CCOpt.(<+>) in
+        let (<+>) = CCOption.(<+>) in
         let top_level ~sign ~repl lhs rhs = 
           UnitIdx.retrieve ~sign (!_idx_simpl, idx_sc) (lhs, q_sc)
           |> Iter.find_map (fun (_, rhs', (_,_,_,c'), subst) ->
@@ -2436,7 +2437,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
 
   let equatable ~sign ~cl s t  =
     let idx_sc, q_sc = 1, 0 in
-    let (<+>) = CCOpt.(<+>) in
+    let (<+>) = CCOption.(<+>) in
     let aux s t =
       UnitIdx.retrieve ~sign (!_idx_simpl, idx_sc) (s, q_sc)
       |> Iter.find_map (fun (_, rhs, (_,_,_,c'), subst) ->
@@ -2469,7 +2470,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
           | _ -> premises
         ) (C.ClauseSet.empty) (C.lits c)
       in
-      CCOpt.return_if (not (CCBV.is_empty (CCBV.negate kept_lits)))
+      CCOption.return_if (not (CCBV.is_empty (CCBV.negate kept_lits)))
         (CCBV.select kept_lits (C.lits c), premises)
     in
 
@@ -2508,7 +2509,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
            | Some cl -> Some (C.ClauseSet.singleton cl)
            | None -> (T.Seq.common_contexts lhs rhs 
                      |> Iter.find_map (fun (a,b) -> equatable ~sign:true ~cl:c a b)
-                     |> CCOpt.map C.ClauseSet.singleton)
+                     |> CCOption.map C.ClauseSet.singleton)
     in
 
     let do_strong_sr = driver ~is_simplified:strong_sr_pair in
@@ -2550,7 +2551,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
     (* try to remove the literal using a negative unit clause *)
     and can_refute s t =
       equatable ~sign:false ~cl:c s t
-      |> CCOpt.map C.proof_parent
+      |> CCOption.map C.proof_parent
     in
     (* fold over literals *)
     let lits, premises = iterate_lits [] (C.lits c |> Array.to_list) [] in
@@ -2799,7 +2800,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
     ZProf.exit_prof _span;
     res
 
-  let eq_subsumes a b = CCOpt.is_some (eq_subsumes_with (a,1) (b,0))
+  let eq_subsumes a b = CCOption.is_some (eq_subsumes_with (a,1) (b,0))
 
   let subsumed_by_active_set c =
     let _span = ZProf.enter_prof prof_subsumption_set in
@@ -2903,7 +2904,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
                     | None -> subsumes_with (C.lits c',1) (lits,0)
                   in
                   subst
-                  |> CCOpt.map
+                  |> CCOption.map
                     (fun (subst,tags) ->
                        (* remove the literal and recurse *)
                        CCArray.except_idx lits i, i, c', subst, tags))
@@ -3050,7 +3051,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
       if condition then raise Fail in
 
     let find_in_args var args =
-      fst @@ CCOpt.get_or ~default:(-1, T.true_)
+      fst @@ CCOption.get_or ~default:(-1, T.true_)
         (CCList.find_idx (T.equal var) args) in
 
     try 
@@ -3131,9 +3132,9 @@ module Make(Env : Env.S) : S with module Env = Env = struct
   let normalize_equalities c =
     let lits = Array.to_list (C.lits c) in
     let normalized = List.map Literal.normalize_eq lits in
-    if List.exists CCOpt.is_some normalized then (
+    if List.exists CCOption.is_some normalized then (
       let new_lits = List.mapi (fun i l_opt -> 
-          CCOpt.get_or ~default:(Array.get (C.lits c) i) l_opt) normalized in
+          CCOption.get_or ~default:(Array.get (C.lits c) i) l_opt) normalized in
       let proof = Proof.Step.simp [C.proof_parent c] 
           ~rule:(Proof.Rule.mk "simplify nested equalities")  in
       let new_c = C.create ~trail:(C.trail c) ~penalty:(C.penalty c) new_lits proof in
@@ -3155,22 +3156,22 @@ module Make(Env : Env.S) : S with module Env = Env = struct
 
   let setup_dot_printers () =
     let pp_leaf _ _ = () in
-    CCOpt.iter
+    CCOption.iter
       (fun file ->
          Signal.once Signals.on_dot_output
            (fun () -> _print_idx ~f:(TermIndex.to_dot pp_leaf) file !_idx_sup_into))
     @@ Env.flex_get k_dot_sup_into;
-    CCOpt.iter
+    CCOption.iter
       (fun file ->
          Signal.once Signals.on_dot_output
            (fun () -> _print_idx ~f:(TermIndex.to_dot pp_leaf) file !_idx_sup_from))
     @@ Env.flex_get k_dot_sup_from;
-    CCOpt.iter
+    CCOption.iter
       (fun file ->
          Signal.once Signals.on_dot_output
            (fun () -> _print_idx ~f:UnitIdx.to_dot file !_idx_simpl))
     @@ Env.flex_get k_dot_simpl;
-    CCOpt.iter
+    CCOption.iter
       (fun file ->
          Signal.once Signals.on_dot_output
            (fun () -> _print_idx ~f:(TermIndex.to_dot pp_leaf) file !_idx_back_demod))

--- a/src/prover_calculi/superposition.mli
+++ b/src/prover_calculi/superposition.mli
@@ -17,7 +17,7 @@ val key : (module S) Flex_state.key
     calling [register]), the Env's state contains
     a mapping from "superposition" to the packed module. *)
 
-val k_unif_alg : (Term.t Scoped.t -> Term.t Scoped.t -> Unif_subst.t CCOpt.t OSeq.t) Flex_state.key
+val k_unif_alg : (Term.t Scoped.t -> Term.t Scoped.t -> Unif_subst.t CCOption.t OSeq.t) Flex_state.key
 val k_ho_basic_rules : bool Flex_state.key
 val get_unif_module : (module Env.S) -> (module UnifFramework.US)
 

--- a/src/prover_phases/dune
+++ b/src/prover_phases/dune
@@ -4,5 +4,5 @@
   (synopsis "main for the Zipperposition theorem prover")
   (libraries libzipperposition libzipperposition.calculi
              libzipperposition.avatar libzipperposition.induction)
-  (flags :standard -w -32)
+  (flags :standard -w -a)
 )

--- a/src/prover_phases/phases_impl.ml
+++ b/src/prover_phases/phases_impl.ml
@@ -227,7 +227,7 @@ let compute_prec ~signature stmts =
           |> Iter.flat_map Statement.Seq.terms
           |> Iter.flat_map (fun t -> Term.Seq.subterms_depth t
                                      |> Iter.filter_map (fun (st,d) -> 
-                                         CCOpt.map (fun id -> (id,d)) (Term.head st)))  in
+                                         CCOption.map (fun id -> (id,d)) (Term.head st)))  in
         let clauses = Iter.map Statement.Seq.lits stmts in
         Precedence.weight_fun_of_string ~signature ~clauses ~lm_w:!_lmb_w ~db_w:!_db_w !_kbo_wf sym_depth)
     (* |> Compute_prec.set_weight_rule (fun _ -> Classify_cst.weight_fun) *)
@@ -514,7 +514,7 @@ let syms_in_conj decls =
   |> CCVector.to_iter
   |> flat_map (fun st -> 
       let pr = Statement.proof_step st in
-      if CCOpt.is_some (Proof.Step.distance_to_goal pr) then (
+      if CCOption.is_some (Proof.Step.distance_to_goal pr) then (
         Statement.Seq.symbols st
       ) else empty)
 

--- a/src/solving/dune
+++ b/src/solving/dune
@@ -5,4 +5,4 @@
   (synopsis "solving constraints")
   (optional)
   (libraries containers logtk msat msat.tseitin iter)
-  (flags :standard -w -32))
+  (flags :standard ))

--- a/src/tools/dune
+++ b/src/tools/dune
@@ -12,6 +12,6 @@
   (promote (until-clean) (into ../..))
   (libraries logtk logtk.parsers)
   (package zipperposition-tools)
-  (flags :standard -w -32)
+  (flags :standard -w -a)
   (ocamlopt_flags :standard -Oclassic)
 )

--- a/src/tools/problem_features.ml
+++ b/src/tools/problem_features.ml
@@ -302,10 +302,10 @@ let process file =
   | CCResult.Ok () ->
     List.iter (function
       | Counter n ->
-        if CCOpt.is_none (StrTbl.get cnt_map n) then (
+        if CCOption.is_none (StrTbl.get cnt_map n) then (
           StrTbl.replace cnt_map n 0)
       | Vector n ->
-        if CCOpt.is_none (StrTbl.get vec_map n) then (
+        if CCOption.is_none (StrTbl.get vec_map n) then (
           StrTbl.replace vec_map n [-1]
         )) all_features;
     


### PR DESCRIPTION
it works, but it was done by gemini flash, so beware

P.S. use `echo "use flake" >> .envrc && direnv allow`

<details>

```
 ~/projects/zipperposition   master ±✚  make
Done: 64% (1305/2020, 715 left) (jobs: 0)must pass: ../examples/ac.zf
Done: 99% (2020/2024, 4 left) (jobs: 1)must pass: ../examples/pelletier_problems/pb34.zf
Done: 99% (2081/2098, 17 left) (jobs: 3)must pass: ../examples/polymorph.p
Done: 99% (2087/2098, 11 left) (jobs: 3)must pass: ../examples/regression/bad_set_avatar.zf --avatar=eager
Done: 98% (2104/2129, 25 left) (jobs: 3)must pass: ../examples/regression/contextual_narrow1.zf
Done: 98% (2105/2129, 24 left) (jobs: 3)must pass: ../examples/set_fancy.zf
Done: 98% (2106/2129, 23 left) (jobs: 3)must pass: ../examples/simple_case.zf
must pass: ../examples/regression/npdtree_fail.zf
Done: 98% (2107/2129, 22 left) (jobs: 3)must pass: ../examples/regression/ho_pos.zf
must pass: ../examples/ho/neg_eq1.zf
must pass: ../examples/data/length.zf
Done: 99% (2128/2129, 1 left) (jobs: 1)qcheck random seed: 283228877
Testing `all'.
This run has ID `68PVHXT7'.

  [OK]          units           0   subst.rename.
  [OK]          units           1   subst.unify.
  [OK]          units           2   multiset.max.
  [OK]          units           3   multiset.compare.
  [OK]          units           4   multiset.size.
  [OK]          units           5   ordering.derived_ho_rpo.
  [OK]          units           6   ordering.derived_ho_kbo.
  [OK]          units           7   ordering.lambdafree_rpo.
  [OK]          units           8   ordering.lambdafree_kbo.
  [OK]          units           9   ordering.lambda_kbo.
  [OK]          units          10   ordering.lambda_lpo.
  [OK]          units          11   db shift.
  [OK]          units          12   db unshift.
  [OK]          units          13   is_appvar.
  [OK]          units          14   whnf1.
  [OK]          units          15   whnf2.
  [OK]          units          16   patterns.
  [OK]          units          17   poly app.
  [OK]          units          18   eta reduce.
  [OK]          units          19   eta expand.
  [OK]          units          20   cover_correct.
  [OK]          units          21   check unifiable.
  [OK]          units          22   check unifiable.
  [OK]          units          23   check unifiable.
  [OK]          units          24   check unifiable.
  [OK]          units          25   check unifiable.
  [OK]          units          26   check parsable.
  [OK]          units          27   check unifiable.
  [OK]          units          28   check unifiable.
  [OK]          units          29   check unifiable.
  [OK]          units          30   check unifiable.
  [OK]          units          31   check unifiable.
  [OK]          units          32   check unifiable.
  [OK]          units          33   check unifiable.
  [OK]          units          34   check unifiable.
  [OK]          units          35   regression matching.
  [OK]          units          36   reg_stack_overflow1.
  [OK]          units          37   regression 468.
  [OK]          qcheck          0   term_size_subterm.
  [OK]          qcheck          1   term_replace_same_subterm.
  [OK]          qcheck          2   term_ground_has_no_var.
  [OK]          qcheck          3   variant_have_same_hash_mod_alpha.
  [OK]          qcheck          4   term_min_max_var.
  [OK]          qcheck          5   whnf_preserve_closed.
  [OK]          qcheck          6   whnf_correct.
  [OK]          qcheck          7   whnf_non_redex_is_preserved.
  [OK]          qcheck          8   snf_preserve_closed.
  [OK]          qcheck          9   snf_no_remaining_redex.
  [OK]          qcheck         10   snf_idempotent.
  [OK]          qcheck         11   snf_correct.
  [OK]          qcheck         12   check_fun_fvars_correct.
  [OK]          qcheck         13   eta_reduce_preserves_ty.
  [OK]          qcheck         14   eta_expand_preserves_ty.
  [OK]          qcheck         15   unify_gives_unifier.
  [OK]          qcheck         16   unify_makes_eq.
  [OK]          qcheck         17   unifier_matches_unified_terms.
  [OK]          qcheck         18   unif_term_self_equal.
  [OK]          qcheck         19   unif_term_self_variant.
  [OK]          qcheck         20   unif_term_variant_sound.
  [OK]          qcheck         21   unif_term_variant_sym.
  [OK]          qcheck         22   unif_term_variant_bidir_match.
  [OK]          qcheck         23   unif_lits_variant_bidir_match.
  [OK]          qcheck         24   unif_matching_gives_matcher.
  [OK]          qcheck         25   unif_matching_preserves_rhs.
  [OK]          qcheck         26   unif_matching_same_scope_preserves_rhs.
  [OK]          qcheck         27   cnf_gives_clauses.
  [OK]          qcheck         28   cnf_miniscope_db_closed.
  [OK]          qcheck         29   congruence_term_eq_to_itself.
  [OK]          qcheck         30   congruence_class_members_are_eq.
  [OK]          qcheck         31   congruence_ref.
  [OK]          qcheck         32   index(dtree)_size_after_add.
  [OK]          qcheck         33   index(dtree)_gen_retrieved_member.
  [OK]          qcheck         34   index(dtree)_gen_retrieved_match.
  [OK]          qcheck         35   index(dtree)_all_matching_are_retrieved.
  [OK]          qcheck         36   index(npdtree)_size_after_add.
  [OK]          qcheck         37   index(npdtree)_gen_retrieved_member.
  [OK]          qcheck         38   index(npdtree)_gen_retrieved_match.
  [OK]          qcheck         39   index(npdtree)_all_matching_are_retrieved.
  [OK]          qcheck         40   index(fingerprint_idx)_size_after_add.
  [OK]          qcheck         41   index(fingerprint_idx)_retrieve_imply_unify.
  [OK]          qcheck         42   index(fingerprint_idx)_retrieve_imply_generalizations.
  [OK]          qcheck         43   index(fingerprint_idx)_retrieve_imply_specializations.
  [OK]          qcheck         44   index(fingerprint_idx)_retrieve_imply_all_unify.
  [OK]          qcheck         45   index(fingerprint_idx)_retrieve_imply_all_generalizations.
  [OK]          qcheck         46   index(fingerprint_idx)_retrieve_imply_all_specializations.
  [OK]          qcheck         47   index(npdtree)_size_after_add.
  [OK]          qcheck         48   index(npdtree)_retrieve_imply_unify.
  [OK]          qcheck         49   index(npdtree)_retrieve_imply_generalizations.
  [OK]          qcheck         50   index(npdtree)_retrieve_imply_specializations.
  [OK]          qcheck         51   index(npdtree)_retrieve_imply_all_unify.
  [OK]          qcheck         52   index(npdtree)_retrieve_imply_all_generalizations.
  [OK]          qcheck         53   index(npdtree)_retrieve_imply_all_specializations.
  [OK]          qcheck         54   type_cmp_compatible_eq.
  [OK]          qcheck         55   ordering_derived_ho_kbo_inv_by_subst.
  [OK]          qcheck         56   ordering_derived_ho_kbo_transitive.
  [OK]          qcheck         57   ordering_derived_ho_kbo_swap_args.
  [OK]          qcheck         58   ordering_derived_ho_kbo_subterm_property.
  [OK]          qcheck         59   ordering_derived_ho_rpo_inv_by_subst.
  [OK]          qcheck         60   ordering_derived_ho_rpo_transitive.
  [OK]          qcheck         61   ordering_derived_ho_rpo_swap_args.
  [OK]          qcheck         62   ordering_derived_ho_rpo_subterm_property.
  [OK]          qcheck         63   ordering_lambda_kbo_inv_by_subst.
  [OK]          qcheck         64   ordering_lambda_kbo_transitive.
  [OK]          qcheck         65   ordering_lambda_kbo_swap_args.
  [OK]          qcheck         66   ordering_lambda_kbo_subterm_property.
  [OK]          qcheck         67   ordering_lambdafree_kbo_inv_by_subst.
  [OK]          qcheck         68   ordering_lambdafree_kbo_transitive.
  [OK]          qcheck         69   ordering_lambdafree_kbo_swap_args.
  [OK]          qcheck         70   ordering_lambdafree_kbo_subterm_property.
  [OK]          qcheck         71   ordering_lambdafree_rpo_inv_by_subst.
  [OK]          qcheck         72   ordering_lambdafree_rpo_transitive.
  [OK]          qcheck         73   ordering_lambdafree_rpo_swap_args.
  [OK]          qcheck         74   ordering_lambdafree_rpo_subterm_property.
  [OK]          qcheck         75   ordering_epo_inv_by_subst.
  [OK]          qcheck         76   ordering_epo_transitive.
  [OK]          qcheck         77   ordering_epo_swap_args.
  [OK]          qcheck         78   ordering_epo_subterm_property.
  [OK]          qcheck         79   multiset_compare_and_compare_partial.
  [OK]          qcheck         80   multiset_compare_partial_sym.
  [OK]          qcheck         81   multiset_compare_partial_trans.
  [OK]          qcheck         82   multiset_max_l_is_max.
  [OK]          qcheck         83   multiset_max_seq.

Full test results in `~/projects/zipperposition/_build/default/tests/_build/_tests/all'.
Test Successful in 15.234s. 122 tests run.
```

</details>